### PR TITLE
Restore tests + enforce javac-compatible layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,26 @@ jobs:
           path: build/reports/checkstyle/
           retention-days: 14
 
+  javac:
+    name: javac (no Gradle)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Compile main sources with javac
+        run: |
+          mkdir -p out-javac
+          find src -name '*.java' \
+            ! -name '*Test.java' \
+            ! -name '*TestHelpers.java' \
+            ! -name 'OilExample.java' > sources.txt
+          javac -encoding UTF-8 -Xlint:none \
+            -d out-javac -cp "lib/*" @sources.txt
+
   spotbugs:
     name: SpotBugs
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ sourceSets {
     main {
         java {
             srcDirs = ['src']
-            exclude 'test/**'
+            exclude '**/*Test.java'
+            exclude '**/*TestHelpers.java'
             // OilExample.java has a text block exceeding JVM's 65535-byte constant pool limit.
             // It compiles under Eclipse's ecj but not javac. Exclude until the string is split.
             exclude '**/OilExample.java'
@@ -33,7 +34,9 @@ sourceSets {
     }
     test {
         java {
-            srcDirs = ['src/test/java']
+            srcDirs = ['src']
+            include '**/*Test.java'
+            include '**/*TestHelpers.java'
         }
     }
 }
@@ -101,7 +104,7 @@ spotless {
     ratchetFrom 'HEAD'
     java {
         target 'src/**/*.java'
-        targetExclude 'src/test/**', '**/easik/**', '**/com/**', '**/OilExample.java'
+        targetExclude '**/*Test.java', '**/*TestHelpers.java', '**/easik/**', '**/com/**', '**/OilExample.java'
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()

--- a/src/catdata/apg/ApgInstanceTest.java
+++ b/src/catdata/apg/ApgInstanceTest.java
@@ -1,0 +1,250 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import catdata.Pair;
+import catdata.cql.Kind;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgInstanceTest {
+
+  private static final Map<String, Pair<Class<?>, Function<String, Object>>> INT_TYS =
+      Map.of("Int", new Pair<>(Integer.class, (Function<String, Object>) Integer::parseInt));
+
+  private static ApgTypeside emptyTypeside() {
+    return new ApgTypeside(Collections.emptyMap(), Collections.emptyMap());
+  }
+
+  private static ApgTypeside intTypeside() {
+    return new ApgTypeside(new HashMap<>(INT_TYS), Collections.emptyMap());
+  }
+
+  private static ApgSchema<String> emptySchema() {
+    return new ApgSchema<>(emptyTypeside(), new HashMap<>());
+  }
+
+  private static ApgSchema<String> personSchema() {
+    return new ApgSchema<>(intTypeside(), new HashMap<>(Map.of("person", ApgTy.ApgTyB("Int"))));
+  }
+
+  @Nested
+  class ConstructorTest {
+
+    @Test
+    void emptyInstanceCreatesSuccessfully() {
+      assertDoesNotThrow(() -> new ApgInstance<>(emptySchema(), Collections.emptyMap()));
+    }
+
+    @Test
+    void instanceWithElementCreatesSuccessfully() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      assertDoesNotThrow(() -> new ApgInstance<>(schema, es));
+    }
+
+    @Test
+    void constructorValidates() {
+      ApgSchema<String> schema = emptySchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("missing", ApgTerm.ApgTermV(42, "Int")));
+      assertThrows(RuntimeException.class, () -> new ApgInstance<>(schema, es));
+    }
+  }
+
+  @Nested
+  class KindAndSizeTest {
+
+    @Test
+    void kindReturnsApgInstance() {
+      ApgInstance<String, String> inst = new ApgInstance<>(emptySchema(), Collections.emptyMap());
+      assertEquals(Kind.APG_instance, inst.kind());
+    }
+
+    @Test
+    void sizeReturnsSumOfEsAndLs() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, es);
+      assertEquals(1 + 1, inst.size());
+    }
+  }
+
+  @Nested
+  class ValidateTest {
+
+    @Test
+    void throwsForUnknownLabel() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("unknown", ApgTerm.ApgTermV(42, "Int")));
+      assertThrows(RuntimeException.class, () -> new ApgInstance<>(schema, es));
+    }
+
+    @Test
+    void throwsForTypeMismatch() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV("notAnInt", "Int")));
+      assertThrows(RuntimeException.class, () -> new ApgInstance<>(schema, es));
+    }
+  }
+
+  @Nested
+  class TypeCheckTest {
+
+    @Test
+    void typeChecksValueAgainstBaseType() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst =
+          new ApgInstance<>(schema, Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int"))));
+      assertDoesNotThrow(() -> inst.type(ApgTerm.ApgTermV(99, "Int"), ApgTy.ApgTyB("Int")));
+    }
+
+    @Test
+    void typeChecksElementReference() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, es);
+      assertDoesNotThrow(
+          () -> inst.type(ApgTerm.ApgTermE("e1"), ApgTy.ApgTyL("person")));
+    }
+
+    @Test
+    void typeChecksTupleAgainstProductType() {
+      ApgSchema<String> schema =
+          new ApgSchema<>(
+              intTypeside(),
+              new HashMap<>(
+                  Map.of("rec", ApgTy.ApgTyP(true, Map.of("age", ApgTy.ApgTyB("Int"))))));
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of(
+              "e1",
+              new Pair<>(
+                  "rec",
+                  ApgTerm.ApgTermTuple(Map.of("age", ApgTerm.ApgTermV(30, "Int")))));
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, es);
+      ApgTerm<String, String> tuple = ApgTerm.ApgTermTuple(Map.of("age", ApgTerm.ApgTermV(25, "Int")));
+      assertDoesNotThrow(
+          () -> inst.type(tuple, ApgTy.ApgTyP(true, Map.of("age", ApgTy.ApgTyB("Int")))));
+    }
+
+    @Test
+    void typeChecksInjectionAgainstSumType() {
+      ApgTy<String> sumTy = ApgTy.ApgTyP(false, Map.of("left", ApgTy.ApgTyB("Int")));
+      ApgSchema<String> schema =
+          new ApgSchema<>(intTypeside(), new HashMap<>(Map.of("choice", sumTy)));
+      ApgTerm<String, String> inj =
+          ApgTerm.ApgTermInj("left", ApgTerm.ApgTermV(1, "Int"), ApgTy.ApgTyB("Int"));
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("choice", inj));
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, es);
+      ApgTerm<String, String> inj2 =
+          ApgTerm.ApgTermInj("left", ApgTerm.ApgTermV(2, "Int"), ApgTy.ApgTyB("Int"));
+      assertDoesNotThrow(() -> inst.type(inj2, sumTy));
+    }
+
+    @Test
+    void throwsForVariableTerm() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, Collections.emptyMap());
+      ApgTerm<String, String> varTerm = ApgTerm.ApgTermVar("x");
+      assertThrows(
+          RuntimeException.class,
+          () -> inst.type(varTerm, ApgTy.ApgTyB("Int")));
+    }
+
+    @Test
+    void throwsForProjectionTerm() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, Collections.emptyMap());
+      ApgTerm<String, String> projTerm =
+          ApgTerm.ApgTermProj("f", ApgTerm.ApgTermTuple(Collections.emptyMap()));
+      assertThrows(
+          RuntimeException.class,
+          () -> inst.type(projTerm, ApgTy.ApgTyB("Int")));
+    }
+  }
+
+  @Nested
+  class ElemsForTest {
+
+    @Test
+    void throwsForBaseType() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, Collections.emptyMap());
+      assertThrows(RuntimeException.class, () -> inst.elemsFor(ApgTy.ApgTyB("Int")));
+    }
+
+    @Test
+    void returnsElementsForLabelType() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es = new HashMap<>();
+      es.put("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      es.put("e2", new Pair<>("person", ApgTerm.ApgTermV(99, "Int")));
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, es);
+      List<ApgTerm<String, String>> result = inst.elemsFor(ApgTy.ApgTyL("person"));
+      assertEquals(2, result.size());
+    }
+
+    @Test
+    void returnsEmptyForLabelWithNoElements() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = new ApgInstance<>(schema, Collections.emptyMap());
+      List<ApgTerm<String, String>> result = inst.elemsFor(ApgTy.ApgTyL("person"));
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  class EqualsTest {
+
+    @Test
+    void equalsSame() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      ApgInstance<String, String> i1 = new ApgInstance<>(schema, es);
+      ApgInstance<String, String> i2 = new ApgInstance<>(schema, new HashMap<>(es));
+      assertEquals(i1, i2);
+    }
+
+    @Test
+    void notEqualsDifferent() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> i1 =
+          new ApgInstance<>(schema, Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int"))));
+      ApgInstance<String, String> i2 =
+          new ApgInstance<>(schema, Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(99, "Int"))));
+      assertNotEquals(i1, i2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgInstance<String, String> inst = new ApgInstance<>(emptySchema(), Collections.emptyMap());
+      assertEquals(inst, inst);
+    }
+
+    @Test
+    void hashCodeConsistent() {
+      ApgSchema<String> schema = personSchema();
+      Map<String, Pair<String, ApgTerm<String, String>>> es =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      ApgInstance<String, String> i1 = new ApgInstance<>(schema, es);
+      ApgInstance<String, String> i2 = new ApgInstance<>(schema, new HashMap<>(es));
+      assertEquals(i1.hashCode(), i2.hashCode());
+    }
+  }
+}

--- a/src/catdata/apg/ApgOpsTest.java
+++ b/src/catdata/apg/ApgOpsTest.java
@@ -1,0 +1,300 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import catdata.Chc;
+import catdata.Pair;
+import catdata.Unit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgOpsTest {
+
+  private ApgTypeside emptyTs;
+  private ApgTypeside intTs;
+
+  @BeforeEach
+  void setUp() {
+    emptyTs = new ApgTypeside(Collections.emptyMap(), Collections.emptyMap());
+
+    Map<String, Pair<Class<?>, Function<String, Object>>> tys = new HashMap<>();
+    tys.put("Int", new Pair<>(Integer.class, (Function<String, Object>) Integer::parseInt));
+    intTs = new ApgTypeside(tys, Collections.emptyMap());
+  }
+
+  private ApgSchema<String> singleLabelSchema(String label) {
+    Map<String, ApgTy<String>> m = new HashMap<>();
+    m.put(label, ApgTy.ApgTyB("Int"));
+    return new ApgSchema<>(intTs, m);
+  }
+
+  private ApgInstance<String, String> emptyInstance(ApgSchema<String> schema) {
+    return new ApgInstance<>(schema, Collections.emptyMap());
+  }
+
+  private ApgInstance<String, String> singleElementInstance(String label, String elemKey,
+      int value) {
+    ApgSchema<String> schema = singleLabelSchema(label);
+    Map<String, Pair<String, ApgTerm<String, String>>> es = new HashMap<>();
+    es.put(elemKey, new Pair<>(label, ApgTerm.ApgTermV(value, "Int")));
+    return new ApgInstance<>(schema, es);
+  }
+
+  @Nested
+  class IdTest {
+
+    @Test
+    void idReturnsIdentityTransform() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, String, String, String> id = ApgOps.id(inst);
+      assertNotNull(id);
+      assertEquals(inst, id.src);
+      assertEquals(inst, id.dst);
+    }
+
+    @Test
+    void idMapsLabelsToSelf() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, String, String, String> id = ApgOps.id(inst);
+      assertEquals("person", id.lMap.get("person"));
+    }
+
+    @Test
+    void idMapsElementsToSelf() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, String, String, String> id = ApgOps.id(inst);
+      assertEquals("e1", id.eMap.get("e1"));
+    }
+  }
+
+  @Nested
+  class ComposeTest {
+
+    @Test
+    void composeTwoIdentities() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, String, String, String> id = ApgOps.id(inst);
+      ApgTransform<String, String, String, String> composed = ApgOps.compose(id, id);
+      assertEquals("person", composed.lMap.get("person"));
+      assertEquals("e1", composed.eMap.get("e1"));
+    }
+
+    @Test
+    void composeProducesCorrectMaps() {
+      ApgSchema<String> schema = singleLabelSchema("person");
+      Map<String, Pair<String, ApgTerm<String, String>>> es1 = new HashMap<>();
+      es1.put("a", new Pair<>("person", ApgTerm.ApgTermV(1, "Int")));
+      ApgInstance<String, String> inst1 = new ApgInstance<>(schema, es1);
+
+      Map<String, Pair<String, ApgTerm<String, String>>> es2 = new HashMap<>();
+      es2.put("b", new Pair<>("person", ApgTerm.ApgTermV(2, "Int")));
+      ApgInstance<String, String> inst2 = new ApgInstance<>(schema, es2);
+
+      Map<String, Pair<String, ApgTerm<String, String>>> es3 = new HashMap<>();
+      es3.put("c", new Pair<>("person", ApgTerm.ApgTermV(3, "Int")));
+      ApgInstance<String, String> inst3 = new ApgInstance<>(schema, es3);
+
+      Map<String, String> lMap12 = new HashMap<>();
+      lMap12.put("person", "person");
+      Map<String, String> eMap12 = new HashMap<>();
+      eMap12.put("a", "b");
+      ApgTransform<String, String, String, String> t12 =
+          new ApgTransform<>(inst1, inst2, lMap12, eMap12);
+
+      Map<String, String> lMap23 = new HashMap<>();
+      lMap23.put("person", "person");
+      Map<String, String> eMap23 = new HashMap<>();
+      eMap23.put("b", "c");
+      ApgTransform<String, String, String, String> t23 =
+          new ApgTransform<>(inst2, inst3, lMap23, eMap23);
+
+      ApgTransform<String, String, String, String> composed = ApgOps.compose(t12, t23);
+      assertEquals(inst1, composed.src);
+      assertEquals(inst3, composed.dst);
+      assertEquals("person", composed.lMap.get("person"));
+      assertEquals("c", composed.eMap.get("a"));
+    }
+  }
+
+  @Nested
+  class InitialTest {
+
+    @Test
+    void initialSchemaReturnsEmptyInstance() {
+      ApgSchema<String> schema = singleLabelSchema("person");
+      ApgInstance<String, Void> init = ApgOps.initial(schema);
+      assertNotNull(init);
+      assertTrue(init.Es.isEmpty());
+    }
+
+    @Test
+    void initialTransformFromEmptyToInstance() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, Void, String, String> t = ApgOps.initial(inst);
+      assertNotNull(t);
+      assertTrue(t.src.Es.isEmpty());
+      assertEquals(inst, t.dst);
+    }
+  }
+
+  @Nested
+  class TerminalTest {
+
+    @Test
+    void terminalSchemaHasSingleLabel() {
+      ApgSchema<Unit> ts = ApgOps.terminalSchema(emptyTs);
+      assertEquals(1, ts.size());
+      assertTrue(ts.containsKey(Unit.unit));
+    }
+
+    @Test
+    void terminalInstanceHasSingleElement() {
+      ApgInstance<Unit, Unit> term = ApgOps.terminal(emptyTs);
+      assertEquals(1, term.Es.size());
+      assertTrue(term.Es.containsKey(Unit.unit));
+    }
+
+    @Test
+    void terminalTransformMapsAllToUnit() {
+      ApgInstance<String, String> inst = singleElementInstance("person", "e1", 42);
+      ApgTransform<String, String, Unit, Unit> t = ApgOps.terminal(inst);
+      assertEquals(Unit.unit, t.lMap.get("person"));
+      assertEquals(Unit.unit, t.eMap.get("e1"));
+    }
+  }
+
+  @Nested
+  class CoproductTest {
+
+    @Test
+    void coproductOfEmptyInstances() {
+      ApgSchema<String> schema = singleLabelSchema("person");
+      ApgInstance<String, String> empty1 = emptyInstance(schema);
+      ApgInstance<String, String> empty2 = emptyInstance(schema);
+      ApgInstance<Chc<String, String>, Chc<String, String>> coprod =
+          ApgOps.coproduct(empty1, empty2);
+      assertNotNull(coprod);
+      assertTrue(coprod.Es.isEmpty());
+    }
+
+    @Test
+    void coproductCombinesElements() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgInstance<Chc<String, String>, Chc<String, String>> coprod =
+          ApgOps.coproduct(inst1, inst2);
+      assertEquals(2, coprod.Es.size());
+      assertTrue(coprod.Es.containsKey(Chc.inLeft("e1")));
+      assertTrue(coprod.Es.containsKey(Chc.inRight("e2")));
+    }
+
+    @Test
+    void inlMapsToLeft() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgTransform<String, String, Chc<String, String>, Chc<String, String>> inl =
+          ApgOps.inl(inst1, inst2);
+      assertEquals(Chc.inLeft("person"), inl.lMap.get("person"));
+      assertEquals(Chc.inLeft("e1"), inl.eMap.get("e1"));
+    }
+
+    @Test
+    void inrMapsToRight() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgTransform<String, String, Chc<String, String>, Chc<String, String>> inr =
+          ApgOps.inr(inst1, inst2);
+      assertEquals(Chc.inRight("person"), inr.lMap.get("person"));
+      assertEquals(Chc.inRight("e2"), inr.eMap.get("e2"));
+    }
+  }
+
+  @Nested
+  class ProductTest {
+
+    @Test
+    void productOfEmptyInstances() {
+      ApgSchema<String> schema = singleLabelSchema("person");
+      ApgInstance<String, String> empty1 = emptyInstance(schema);
+      ApgInstance<String, String> empty2 = emptyInstance(schema);
+      ApgInstance<Pair<String, String>, Pair<String, String>> prod =
+          ApgOps.product(empty1, empty2);
+      assertNotNull(prod);
+      assertTrue(prod.Es.isEmpty());
+    }
+
+    @Test
+    void productCombinesElements() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgInstance<Pair<String, String>, Pair<String, String>> prod =
+          ApgOps.product(inst1, inst2);
+      assertEquals(1, prod.Es.size());
+      assertTrue(prod.Es.containsKey(new Pair<>("e1", "e2")));
+    }
+
+    @Test
+    void fstProjectsToFirst() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgTransform<Pair<String, String>, Pair<String, String>, String, String> fst =
+          ApgOps.fst(inst1, inst2);
+      assertEquals("person", fst.lMap.get(new Pair<>("person", "person")));
+      assertEquals("e1", fst.eMap.get(new Pair<>("e1", "e2")));
+    }
+
+    @Test
+    void sndProjectsToSecond() {
+      ApgInstance<String, String> inst1 = singleElementInstance("person", "e1", 1);
+      ApgInstance<String, String> inst2 = singleElementInstance("person", "e2", 2);
+      ApgTransform<Pair<String, String>, Pair<String, String>, String, String> snd =
+          ApgOps.snd(inst1, inst2);
+      assertEquals("person", snd.lMap.get(new Pair<>("person", "person")));
+      assertEquals("e2", snd.eMap.get(new Pair<>("e1", "e2")));
+    }
+  }
+
+  @Nested
+  class SchemaOpsTest {
+
+    @Test
+    void initialSchemaIsEmpty() {
+      ApgSchema<String> schema = ApgOps.initialSchema(intTs);
+      assertTrue(schema.isEmpty());
+      assertEquals(intTs, schema.typeside);
+    }
+
+    @Test
+    void terminalSchemaHasOneLabel() {
+      ApgSchema<Unit> schema = ApgOps.terminalSchema(emptyTs);
+      assertEquals(1, schema.size());
+      assertTrue(schema.containsKey(Unit.unit));
+    }
+
+    @Test
+    void coproductSchemaUnifiesLabels() {
+      ApgSchema<String> s1 = singleLabelSchema("a");
+      ApgSchema<String> s2 = singleLabelSchema("b");
+      ApgSchema<Chc<String, String>> coprod = ApgOps.coproductSchema(s1, s2);
+      assertEquals(2, coprod.size());
+      assertTrue(coprod.containsKey(Chc.inLeft("a")));
+      assertTrue(coprod.containsKey(Chc.inRight("b")));
+    }
+
+    @Test
+    void productSchemaCrossesLabels() {
+      ApgSchema<String> s1 = singleLabelSchema("a");
+      ApgSchema<String> s2 = singleLabelSchema("b");
+      ApgSchema<Pair<String, String>> prod = ApgOps.productSchema(s1, s2);
+      assertEquals(1, prod.size());
+      assertTrue(prod.containsKey(new Pair<>("a", "b")));
+    }
+  }
+}

--- a/src/catdata/apg/ApgPreTermTest.java
+++ b/src/catdata/apg/ApgPreTermTest.java
@@ -1,0 +1,192 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import catdata.Pair;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgPreTermTest {
+
+  @Nested
+  class StrFactory {
+
+    @Test
+    void strFactorySetsString() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermStr("hello");
+      assertEquals("hello", t.str);
+      assertNull(t.fields);
+      assertNull(t.inj);
+      assertNull(t.ty);
+    }
+
+    @Test
+    void strToString() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermStr("hello");
+      assertEquals("hello", t.toString());
+    }
+  }
+
+  @Nested
+  class TupleFactory {
+
+    @Test
+    void tupleFactorySetsFields() {
+      List<Pair<String, ApgPreTerm>> fields = List.of(
+          new Pair<>("a", ApgPreTerm.ApgPreTermStr("x")),
+          new Pair<>("b", ApgPreTerm.ApgPreTermStr("y")));
+      ApgPreTerm t = ApgPreTerm.ApgPreTermTuple(fields);
+      assertNotNull(t.fields);
+      assertEquals(2, t.fields.size());
+      assertNull(t.str);
+    }
+
+    @Test
+    void tupleToStringContainsComma() {
+      List<Pair<String, ApgPreTerm>> fields = List.of(
+          new Pair<>("a", ApgPreTerm.ApgPreTermStr("x")),
+          new Pair<>("b", ApgPreTerm.ApgPreTermStr("y")));
+      ApgPreTerm t = ApgPreTerm.ApgPreTermTuple(fields);
+      assertTrue(t.toString().contains(","));
+    }
+  }
+
+  @Nested
+  class InjFactory {
+
+    @Test
+    void injFactorySetsFields() {
+      ApgPreTerm inner = ApgPreTerm.ApgPreTermStr("val");
+      ApgPreTerm t = ApgPreTerm.ApgPreTermInj("tag", inner);
+      assertEquals("tag", t.inj);
+      assertEquals(inner, t.arg);
+    }
+
+    @Test
+    void injToStringContainsAngleBrackets() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermInj("tag", ApgPreTerm.ApgPreTermStr("v"));
+      String s = t.toString();
+      assertTrue(s.contains("<"));
+      assertTrue(s.contains(">"));
+    }
+  }
+
+  @Nested
+  class BaseFactory {
+
+    @Test
+    void baseFactorySetsStringAndType() {
+      ApgTy<Object> ty = ApgTy.ApgTyB("Int");
+      ApgPreTerm t = ApgPreTerm.ApgPreTermBase("42", ty);
+      assertEquals("42", t.str);
+      assertEquals(ty, t.ty);
+    }
+
+    @Test
+    void baseToStringContainsAtSign() {
+      ApgTy<Object> ty = ApgTy.ApgTyB("Int");
+      ApgPreTerm t = ApgPreTerm.ApgPreTermBase("42", ty);
+      assertTrue(t.toString().contains("@"));
+    }
+  }
+
+  @Nested
+  class ProjFactory {
+
+    @Test
+    void projFactorySetsFields() {
+      ApgPreTerm inner = ApgPreTerm.ApgPreTermStr("x");
+      ApgPreTerm t = ApgPreTerm.ApgPreTermProj("name", inner);
+      assertEquals("name", t.proj);
+      assertEquals(inner, t.arg);
+    }
+
+    @Test
+    void projToStringContainsDot() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermProj("name", ApgPreTerm.ApgPreTermStr("x"));
+      assertTrue(t.toString().contains("."));
+    }
+  }
+
+  @Nested
+  class DerefFactory {
+
+    @Test
+    void derefFactorySetsFields() {
+      ApgPreTerm inner = ApgPreTerm.ApgPreTermStr("x");
+      ApgPreTerm t = ApgPreTerm.ApgPreTermDeref("ref", inner);
+      assertEquals("ref", t.deref);
+      assertEquals(inner, t.arg);
+    }
+
+    @Test
+    void derefToStringContainsBang() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermDeref("ref", ApgPreTerm.ApgPreTermStr("x"));
+      assertTrue(t.toString().contains("!"));
+    }
+  }
+
+  @Nested
+  class AppFactory {
+
+    @Test
+    void appFactorySetsFields() {
+      List<ApgPreTerm> args = List.of(
+          ApgPreTerm.ApgPreTermStr("a"),
+          ApgPreTerm.ApgPreTermStr("b"));
+      ApgPreTerm t = ApgPreTerm.ApgPreTermApp("fn", args);
+      assertEquals("fn", t.head);
+      assertEquals(2, t.args.size());
+    }
+
+    @Test
+    void appToStringContainsParens() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermApp("fn", List.of(ApgPreTerm.ApgPreTermStr("a")));
+      String s = t.toString();
+      assertTrue(s.contains("("));
+      assertTrue(s.contains(")"));
+    }
+  }
+
+  @Nested
+  class Equality {
+
+    @Test
+    void equalsSameStr() {
+      ApgPreTerm t1 = ApgPreTerm.ApgPreTermStr("hello");
+      ApgPreTerm t2 = ApgPreTerm.ApgPreTermStr("hello");
+      assertEquals(t1, t2);
+    }
+
+    @Test
+    void notEqualsDifferentStr() {
+      ApgPreTerm t1 = ApgPreTerm.ApgPreTermStr("hello");
+      ApgPreTerm t2 = ApgPreTerm.ApgPreTermStr("world");
+      assertNotEquals(t1, t2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermStr("x");
+      assertEquals(t, t);
+    }
+
+    @Test
+    void notEqualsNull() {
+      ApgPreTerm t = ApgPreTerm.ApgPreTermStr("x");
+      assertNotEquals(null, t);
+    }
+
+    @Test
+    void hashCodeConsistent() {
+      ApgPreTerm t1 = ApgPreTerm.ApgPreTermStr("hello");
+      ApgPreTerm t2 = ApgPreTerm.ApgPreTermStr("hello");
+      assertEquals(t1.hashCode(), t2.hashCode());
+    }
+  }
+}

--- a/src/catdata/apg/ApgSchemaTest.java
+++ b/src/catdata/apg/ApgSchemaTest.java
@@ -1,0 +1,170 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import catdata.cql.Kind;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgSchemaTest {
+
+  private static ApgTypeside emptyTypeside() {
+    return new ApgTypeside(Collections.emptyMap(), Collections.emptyMap());
+  }
+
+  private static ApgSchema<String> emptySchema() {
+    return new ApgSchema<>(emptyTypeside(), new HashMap<>());
+  }
+
+  private static ApgSchema<String> singleLabelSchema() {
+    Map<String, ApgTy<String>> map = new HashMap<>();
+    map.put("Person", ApgTy.ApgTyB("Int"));
+    return new ApgSchema<>(emptyTypeside(), map);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTypeside ts = emptyTypeside();
+      Map<String, ApgTy<String>> map = new HashMap<>();
+      ApgSchema<String> schema = new ApgSchema<>(ts, map);
+      assertEquals(ts, schema.typeside);
+      assertEquals(map, schema.schema);
+    }
+  }
+
+  @Nested
+  class SemanticsMethods {
+
+    @Test
+    void kindReturnsApgSchema() {
+      assertEquals(Kind.APG_schema, emptySchema().kind());
+    }
+
+    @Test
+    void sizeMatchesSchemaSize() {
+      assertEquals(0, emptySchema().size());
+      assertEquals(1, singleLabelSchema().size());
+    }
+  }
+
+  @Nested
+  class MapDelegation {
+
+    @Test
+    void isEmptyWhenSchemaEmpty() {
+      assertTrue(emptySchema().isEmpty());
+      assertFalse(singleLabelSchema().isEmpty());
+    }
+
+    @Test
+    void containsKeyDelegates() {
+      ApgSchema<String> schema = singleLabelSchema();
+      assertTrue(schema.containsKey("Person"));
+      assertFalse(schema.containsKey("Animal"));
+    }
+
+    @Test
+    void getDelegates() {
+      ApgSchema<String> schema = singleLabelSchema();
+      ApgTy<String> ty = schema.get("Person");
+      assertEquals(ApgTy.ApgTyB("Int"), ty);
+      assertNull(schema.get("Missing"));
+    }
+
+    @Test
+    void putDelegates() {
+      ApgSchema<String> schema = emptySchema();
+      schema.put("Name", ApgTy.ApgTyB("String"));
+      assertEquals(1, schema.size());
+      assertTrue(schema.containsKey("Name"));
+    }
+
+    @Test
+    void removeDelegates() {
+      ApgSchema<String> schema = singleLabelSchema();
+      schema.remove("Person");
+      assertTrue(schema.isEmpty());
+    }
+
+    @Test
+    void keySetDelegates() {
+      ApgSchema<String> schema = singleLabelSchema();
+      assertTrue(schema.keySet().contains("Person"));
+      assertEquals(1, schema.keySet().size());
+    }
+  }
+
+  @Nested
+  class Equality {
+
+    @Test
+    void equalsSame() {
+      ApgTypeside ts = emptyTypeside();
+      Map<String, ApgTy<String>> map = new HashMap<>();
+      map.put("X", ApgTy.ApgTyB("Int"));
+      ApgSchema<String> s1 = new ApgSchema<>(ts, map);
+      ApgSchema<String> s2 = new ApgSchema<>(ts, new HashMap<>(map));
+      assertEquals(s1, s2);
+    }
+
+    @Test
+    void notEqualsDifferentSchema() {
+      ApgTypeside ts = emptyTypeside();
+      Map<String, ApgTy<String>> map1 = new HashMap<>();
+      map1.put("X", ApgTy.ApgTyB("Int"));
+      Map<String, ApgTy<String>> map2 = new HashMap<>();
+      map2.put("Y", ApgTy.ApgTyB("Int"));
+      assertNotEquals(new ApgSchema<>(ts, map1), new ApgSchema<>(ts, map2));
+    }
+
+    @Test
+    void notEqualsDifferentTypeside() {
+      Map<String, ApgTy<String>> map = new HashMap<>();
+      ApgSchema<String> s1 = new ApgSchema<>(emptyTypeside(), map);
+      ApgSchema<String> s2 = new ApgSchema<>(null, map);
+      assertNotEquals(s1, s2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgSchema<String> s = singleLabelSchema();
+      assertEquals(s, s);
+    }
+
+    @Test
+    void notEqualsNull() {
+      assertNotEquals(null, singleLabelSchema());
+    }
+
+    @Test
+    void hashCodeConsistent() {
+      ApgTypeside ts = emptyTypeside();
+      Map<String, ApgTy<String>> map = new HashMap<>();
+      map.put("X", ApgTy.ApgTyB("Int"));
+      ApgSchema<String> s1 = new ApgSchema<>(ts, map);
+      ApgSchema<String> s2 = new ApgSchema<>(ts, new HashMap<>(map));
+      assertEquals(s1.hashCode(), s2.hashCode());
+    }
+  }
+
+  @Nested
+  class ToStringTest {
+
+    @Test
+    void toStringContainsLabels() {
+      ApgSchema<String> schema = singleLabelSchema();
+      String str = schema.toString();
+      assertTrue(str.contains("labels"));
+    }
+  }
+}

--- a/src/catdata/apg/ApgTermTest.java
+++ b/src/catdata/apg/ApgTermTest.java
@@ -1,0 +1,273 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTermTest {
+
+  @Nested
+  class ApgTermETest {
+
+    @Test
+    void factorySetsElement() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermE("elem1");
+      assertEquals("elem1", t.e);
+      assertNull(t.value);
+      assertNull(t.fields);
+      assertNull(t.inj);
+      assertNull(t.var);
+    }
+
+    @Test
+    void cachedSameReference() {
+      ApgTerm<String, String> t1 = ApgTerm.ApgTermE("cached_elem");
+      ApgTerm<String, String> t2 = ApgTerm.ApgTermE("cached_elem");
+      assertSame(t1, t2);
+    }
+
+    @Test
+    void toStringReturnsElement() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermE("hello");
+      assertEquals("hello", t.toString());
+    }
+  }
+
+  @Nested
+  class ApgTermVTest {
+
+    @Test
+    void factorySetsValueAndPrim() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermV(42, "Int");
+      assertEquals(42, t.value);
+      assertEquals("Int", t.prim);
+      assertNull(t.e);
+      assertNull(t.fields);
+    }
+
+    @Test
+    void toStringReturnsValue() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermV(42, "Int");
+      assertEquals("42", t.toString());
+    }
+  }
+
+  @Nested
+  class ApgTermTupleTest {
+
+    @Test
+    void factorySetsFields() {
+      Map<String, ApgTerm<String, String>> fields = new LinkedHashMap<>();
+      fields.put("x", ApgTerm.ApgTermV(1, "Int"));
+      fields.put("y", ApgTerm.ApgTermV(2, "Int"));
+      ApgTerm<String, String> t = ApgTerm.ApgTermTuple(fields);
+      assertNotNull(t.fields);
+      assertEquals(2, t.fields.size());
+      assertNull(t.e);
+    }
+
+    @Test
+    void toStringContainsColon() {
+      Map<String, ApgTerm<String, String>> fields = new LinkedHashMap<>();
+      fields.put("a", ApgTerm.ApgTermV(1, "Int"));
+      ApgTerm<String, String> t = ApgTerm.ApgTermTuple(fields);
+      assertTrue(t.toString().contains(":"));
+    }
+  }
+
+  @Nested
+  class ApgTermInjTest {
+
+    @Test
+    void factorySetsInjAndArg() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Bool");
+      ApgTerm<String, String> inner = ApgTerm.ApgTermV(true, "Bool");
+      ApgTerm<String, String> t = ApgTerm.ApgTermInj("left", inner, ty);
+      assertEquals("left", t.inj);
+      assertSame(inner, t.a);
+      assertSame(ty, t.cases_t);
+    }
+
+    @Test
+    void toStringContainsAngleBrackets() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Bool");
+      ApgTerm<String, String> inner = ApgTerm.ApgTermV(true, "Bool");
+      ApgTerm<String, String> t = ApgTerm.ApgTermInj("left", inner, ty);
+      String s = t.toString();
+      assertTrue(s.contains("<"));
+      assertTrue(s.contains(">"));
+    }
+  }
+
+  @Nested
+  class ApgTermVarTest {
+
+    @Test
+    void factorySetsVar() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermVar("x");
+      assertEquals("x", t.var);
+      assertNull(t.e);
+      assertNull(t.value);
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermVar("myVar");
+      assertEquals("myVar", t.toString());
+    }
+
+    @Test
+    void substReplacesMatchingVar() {
+      ApgTerm<String, String> varTerm = ApgTerm.ApgTermVar("x");
+      ApgTerm<String, String> replacement = ApgTerm.ApgTermV(99, "Int");
+      ApgTerm<String, String> result = varTerm.subst("x", replacement);
+      assertSame(replacement, result);
+    }
+
+    @Test
+    void substPreservesNonMatchingVar() {
+      ApgTerm<String, String> varTerm = ApgTerm.ApgTermVar("y");
+      ApgTerm<String, String> replacement = ApgTerm.ApgTermV(99, "Int");
+      ApgTerm<String, String> result = varTerm.subst("x", replacement);
+      assertEquals("y", result.var);
+    }
+
+    @Test
+    void renameChangesMatchingVar() {
+      ApgTerm<String, String> varTerm = ApgTerm.ApgTermVar("x");
+      ApgTerm<String, String> result = varTerm.rename("x", "z");
+      assertEquals("z", result.var);
+    }
+
+    @Test
+    void renamePreservesNonMatchingVar() {
+      ApgTerm<String, String> varTerm = ApgTerm.ApgTermVar("y");
+      ApgTerm<String, String> result = varTerm.rename("x", "z");
+      assertSame(varTerm, result);
+    }
+  }
+
+  @Nested
+  class ApgTermProjTest {
+
+    @Test
+    void factorySetsProjAndArg() {
+      ApgTerm<String, String> inner = ApgTerm.ApgTermVar("t");
+      ApgTerm<String, String> t = ApgTerm.ApgTermProj("field1", inner);
+      assertEquals("field1", t.proj);
+      assertSame(inner, t.a);
+    }
+
+    @Test
+    void toStringContainsDot() {
+      ApgTerm<String, String> inner = ApgTerm.ApgTermVar("t");
+      ApgTerm<String, String> t = ApgTerm.ApgTermProj("field1", inner);
+      assertTrue(t.toString().contains("."));
+    }
+  }
+
+  @Nested
+  class ApgTermDerefTest {
+
+    @Test
+    void factorySetsDerefAndArg() {
+      ApgTerm<String, String> inner = ApgTerm.ApgTermVar("t");
+      ApgTerm<String, String> t = ApgTerm.ApgTermDeref("label", inner);
+      assertEquals("label", t.deref);
+      assertSame(inner, t.a);
+    }
+
+    @Test
+    void toStringContainsBang() {
+      ApgTerm<String, String> inner = ApgTerm.ApgTermVar("t");
+      ApgTerm<String, String> t = ApgTerm.ApgTermDeref("label", inner);
+      assertTrue(t.toString().contains("!"));
+    }
+  }
+
+  @Nested
+  class MapTest {
+
+    @Test
+    void mapTransformsElement() {
+      ApgTerm<String, Integer> t = ApgTerm.ApgTermE(5);
+      ApgTerm<String, String> result = t.map(Object::toString);
+      assertEquals("5", result.e);
+    }
+
+    @Test
+    void mapPreservesValue() {
+      ApgTerm<String, Integer> t = ApgTerm.ApgTermV(42, "Int");
+      ApgTerm<String, String> result = t.map(Object::toString);
+      assertEquals(42, result.value);
+      assertEquals("Int", result.prim);
+    }
+
+    @Test
+    void mapPreservesVar() {
+      ApgTerm<String, Integer> t = ApgTerm.ApgTermVar("x");
+      ApgTerm<String, String> result = t.map(Object::toString);
+      assertEquals("x", result.var);
+    }
+
+    @Test
+    void mapTransformsTupleElements() {
+      Map<String, ApgTerm<String, Integer>> fields = new LinkedHashMap<>();
+      fields.put("a", ApgTerm.ApgTermE(1));
+      fields.put("b", ApgTerm.ApgTermE(2));
+      ApgTerm<String, Integer> t = ApgTerm.ApgTermTuple(fields);
+      ApgTerm<String, String> result = t.map(Object::toString);
+      assertNotNull(result.fields);
+      assertEquals("1", result.fields.get("a").e);
+      assertEquals("2", result.fields.get("b").e);
+    }
+
+    @Test
+    void mapTransformsInjElement() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Bool");
+      ApgTerm<String, Integer> inner = ApgTerm.ApgTermE(10);
+      ApgTerm<String, Integer> t = ApgTerm.ApgTermInj("left", inner, ty);
+      ApgTerm<String, String> result = t.map(Object::toString);
+      assertEquals("left", result.inj);
+      assertEquals("10", result.a.e);
+    }
+  }
+
+  @Nested
+  class Equals2Test {
+
+    @Test
+    void sameStructureReturnsTrue() {
+      ApgTerm<String, String> t1 = ApgTerm.ApgTermE("a");
+      ApgTerm<String, String> t2 = ApgTerm.ApgTermE("a");
+      assertTrue(t1.equals2(t2));
+    }
+
+    @Test
+    void differentStructureReturnsFalse() {
+      ApgTerm<String, String> t1 = ApgTerm.ApgTermE("a");
+      ApgTerm<String, String> t2 = ApgTerm.ApgTermE("b");
+      assertFalse(t1.equals2(t2));
+    }
+
+    @Test
+    void reflexive() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermV(42, "Int");
+      assertTrue(t.equals2(t));
+    }
+
+    @Test
+    void nullReturnsFalse() {
+      ApgTerm<String, String> t = ApgTerm.ApgTermVar("x");
+      assertFalse(t.equals2(null));
+    }
+  }
+}

--- a/src/catdata/apg/ApgTransformTest.java
+++ b/src/catdata/apg/ApgTransformTest.java
@@ -1,0 +1,205 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import catdata.Pair;
+import catdata.cql.Kind;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTransformTest {
+
+  private static final Map<String, Pair<Class<?>, Function<String, Object>>> INT_TYS =
+      Map.of("Int", new Pair<>(Integer.class, (Function<String, Object>) Integer::parseInt));
+
+  private static ApgTypeside intTypeside() {
+    return new ApgTypeside(new HashMap<>(INT_TYS), Collections.emptyMap());
+  }
+
+  private static ApgSchema<String> personSchema() {
+    return new ApgSchema<>(intTypeside(), new HashMap<>(Map.of("person", ApgTy.ApgTyB("Int"))));
+  }
+
+  private static ApgInstance<String, String> emptyInstance(ApgSchema<String> schema) {
+    return new ApgInstance<>(schema, Collections.emptyMap());
+  }
+
+  private static ApgInstance<String, String> singletonInstance(ApgSchema<String> schema) {
+    return new ApgInstance<>(
+        schema, Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int"))));
+  }
+
+  @Nested
+  class ConstructorTest {
+
+    @Test
+    void emptyTransformCreatesSuccessfully() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> src = emptyInstance(schema);
+      ApgInstance<String, String> dst = emptyInstance(schema);
+      assertDoesNotThrow(
+          () ->
+              new ApgTransform<>(
+                  src, dst, Collections.emptyMap(), Collections.emptyMap()));
+    }
+
+    @Test
+    void identityTransformCreatesSuccessfully() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      assertDoesNotThrow(
+          () ->
+              new ApgTransform<>(
+                  inst, inst, Map.of("person", "person"), Map.of("e1", "e1")));
+    }
+
+    @Test
+    void throwsForMissingLabelMapping() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransform<>(
+                  inst, inst, Collections.emptyMap(), Map.of("e1", "e1")));
+    }
+
+    @Test
+    void throwsForMissingElementMapping() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransform<>(
+                  inst, inst, Map.of("person", "person"), Collections.emptyMap()));
+    }
+  }
+
+  @Nested
+  class KindAndSizeTest {
+
+    @Test
+    void kindReturnsApgMorphism() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> src = emptyInstance(schema);
+      ApgInstance<String, String> dst = emptyInstance(schema);
+      ApgTransform<String, String, String, String> t =
+          new ApgTransform<>(src, dst, Collections.emptyMap(), Collections.emptyMap());
+      assertEquals(Kind.APG_morphism, t.kind());
+    }
+
+    @Test
+    void sizeReturnsSumOfSrcAndDst() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      ApgTransform<String, String, String, String> t =
+          new ApgTransform<>(inst, inst, Map.of("person", "person"), Map.of("e1", "e1"));
+      assertEquals(inst.size() + inst.size(), t.size());
+    }
+  }
+
+  @Nested
+  class ValidateTest {
+
+    @Test
+    void throwsWhenLabelNotMapped() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransform<>(
+                  inst, inst, Collections.emptyMap(), Map.of("e1", "e1")));
+    }
+
+    @Test
+    void throwsWhenElementNotMapped() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransform<>(
+                  inst, inst, Map.of("person", "person"), Collections.emptyMap()));
+    }
+
+    @Test
+    void throwsWhenLabelsInconsistent() {
+      ApgTypeside ts = intTypeside();
+      ApgSchema<String> schema =
+          new ApgSchema<>(
+              ts,
+              new HashMap<>(
+                  Map.of(
+                      "person", ApgTy.ApgTyB("Int"),
+                      "animal", ApgTy.ApgTyB("Int"))));
+      Map<String, Pair<String, ApgTerm<String, String>>> srcEs =
+          Map.of("e1", new Pair<>("person", ApgTerm.ApgTermV(42, "Int")));
+      Map<String, Pair<String, ApgTerm<String, String>>> dstEs =
+          Map.of("e2", new Pair<>("animal", ApgTerm.ApgTermV(42, "Int")));
+      ApgInstance<String, String> src = new ApgInstance<>(schema, srcEs);
+      ApgInstance<String, String> dst = new ApgInstance<>(schema, dstEs);
+      // Label maps person -> person, but target element e2 has label "animal"
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransform<>(
+                  src, dst, Map.of("person", "person"), Map.of("e1", "e2")));
+    }
+  }
+
+  @Nested
+  class EqualsTest {
+
+    @Test
+    void equalsSame() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      ApgTransform<String, String, String, String> t1 =
+          new ApgTransform<>(inst, inst, Map.of("person", "person"), Map.of("e1", "e1"));
+      ApgTransform<String, String, String, String> t2 =
+          new ApgTransform<>(inst, inst, Map.of("person", "person"), Map.of("e1", "e1"));
+      assertEquals(t1, t2);
+    }
+
+    @Test
+    void notEqualsDifferent() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> src = emptyInstance(schema);
+      ApgInstance<String, String> dst = singletonInstance(schema);
+      ApgTransform<String, String, String, String> t1 =
+          new ApgTransform<>(src, src, Collections.emptyMap(), Collections.emptyMap());
+      ApgTransform<String, String, String, String> t2 =
+          new ApgTransform<>(src, dst, Collections.emptyMap(), Collections.emptyMap());
+      assertNotEquals(t1, t2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = emptyInstance(schema);
+      ApgTransform<String, String, String, String> t =
+          new ApgTransform<>(inst, inst, Collections.emptyMap(), Collections.emptyMap());
+      assertEquals(t, t);
+    }
+
+    @Test
+    void hashCodeConsistent() {
+      ApgSchema<String> schema = personSchema();
+      ApgInstance<String, String> inst = singletonInstance(schema);
+      ApgTransform<String, String, String, String> t1 =
+          new ApgTransform<>(inst, inst, Map.of("person", "person"), Map.of("e1", "e1"));
+      ApgTransform<String, String, String, String> t2 =
+          new ApgTransform<>(inst, inst, Map.of("person", "person"), Map.of("e1", "e1"));
+      assertEquals(t1.hashCode(), t2.hashCode());
+    }
+  }
+}

--- a/src/catdata/apg/ApgTyTest.java
+++ b/src/catdata/apg/ApgTyTest.java
@@ -1,0 +1,237 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTyTest {
+
+  @Nested
+  class FactoryMethods {
+
+    @Test
+    void apgTyLSetsLabel() {
+      ApgTy<String> ty = ApgTy.ApgTyL("myLabel");
+      assertEquals("myLabel", ty.l);
+      assertNull(ty.b);
+      assertNull(ty.m);
+    }
+
+    @Test
+    void apgTyBSetsBaseType() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Int");
+      assertEquals("Int", ty.b);
+      assertNull(ty.l);
+      assertNull(ty.m);
+    }
+
+    @Test
+    void apgTyPSetsProductFields() {
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("name", ApgTy.ApgTyB("String"));
+      fields.put("age", ApgTy.ApgTyB("Int"));
+      ApgTy<String> ty = ApgTy.ApgTyP(true, fields);
+      assertTrue(ty.all);
+      assertNotNull(ty.m);
+      assertEquals(2, ty.m.size());
+      assertNull(ty.l);
+      assertNull(ty.b);
+    }
+
+    @Test
+    void apgTyPSetsSumFields() {
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("left", ApgTy.ApgTyB("Int"));
+      fields.put("right", ApgTy.ApgTyB("String"));
+      ApgTy<String> ty = ApgTy.ApgTyP(false, fields);
+      assertFalse(ty.all);
+      assertNotNull(ty.m);
+      assertEquals(2, ty.m.size());
+    }
+  }
+
+  @Nested
+  class Caching {
+
+    @Test
+    void cachedInstancesSameReference() {
+      ApgTy<String> ty1 = ApgTy.ApgTyB("CachedType");
+      ApgTy<String> ty2 = ApgTy.ApgTyB("CachedType");
+      assertSame(ty1, ty2);
+    }
+  }
+
+  @Nested
+  class EqualsHashCode {
+
+    @Test
+    void identityEquals() {
+      ApgTy<String> ty1 = ApgTy.ApgTyB("X");
+      ApgTy<String> ty2 = ApgTy.ApgTyB("Y");
+      // identity-based equals: same ref returns true
+      assertEquals(ty1, ty1);
+      // different structural types are different references
+      assertNotEquals(ty1, ty2);
+      // even structurally different objects are not equal
+      assertFalse(ty1.equals(ty2));
+    }
+
+    @Test
+    void equals2MatchesStructurally() {
+      // Since the cache returns the same instance for same args,
+      // we test equals2 with two instances that are the same ref
+      ApgTy<String> ty = ApgTy.ApgTyB("Str");
+      assertTrue(ty.equals2(ty));
+
+      // Also test with a label type
+      ApgTy<String> tyL1 = ApgTy.ApgTyL("lab");
+      assertTrue(tyL1.equals2(tyL1));
+    }
+
+    @Test
+    void equals2DifferentStructure() {
+      ApgTy<String> tyB = ApgTy.ApgTyB("Int");
+      ApgTy<String> tyL = ApgTy.ApgTyL("label");
+      assertFalse(tyB.equals2(tyL));
+      assertFalse(tyL.equals2(tyB));
+    }
+
+    @Test
+    void hashCode2ConsistentWithEquals2() {
+      ApgTy<String> ty1 = ApgTy.ApgTyB("HC");
+      ApgTy<String> ty2 = ApgTy.ApgTyB("HC");
+      // Same instance from cache, so equals2 is true
+      assertTrue(ty1.equals2(ty2));
+      assertEquals(ty1.hashCode2(), ty2.hashCode2());
+    }
+  }
+
+  @Nested
+  class ToStringTest {
+
+    @Test
+    void toStringLabel() {
+      ApgTy<String> ty = ApgTy.ApgTyL("Person");
+      assertEquals("Person", ty.toString());
+    }
+
+    @Test
+    void toStringBaseType() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Int");
+      assertEquals("Int", ty.toString());
+    }
+
+    @Test
+    void toStringProduct() {
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("x", ApgTy.ApgTyB("Int"));
+      fields.put("y", ApgTy.ApgTyB("Str"));
+      ApgTy<String> ty = ApgTy.ApgTyP(true, fields);
+      String str = ty.toString();
+      assertTrue(str.startsWith("("), "product toString should start with '(' but was: " + str);
+      assertTrue(str.endsWith(")"), "product toString should end with ')' but was: " + str);
+      assertTrue(str.contains("x"), "product toString should contain field 'x' but was: " + str);
+      assertTrue(str.contains("*"), "product toString should contain '*' separator but was: " + str);
+    }
+
+    @Test
+    void toStringSum() {
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("a", ApgTy.ApgTyB("Int"));
+      fields.put("b", ApgTy.ApgTyB("Str"));
+      ApgTy<String> ty = ApgTy.ApgTyP(false, fields);
+      String str = ty.toString();
+      assertTrue(str.startsWith("<"), "sum toString should start with '<' but was: " + str);
+      assertTrue(str.endsWith(">"), "sum toString should end with '>' but was: " + str);
+      assertTrue(str.contains("a"), "sum toString should contain field 'a' but was: " + str);
+      assertTrue(str.contains("+"), "sum toString should contain '+' separator but was: " + str);
+    }
+  }
+
+  @Nested
+  class MapTest {
+
+    @Test
+    void mapTransformsLabel() {
+      ApgTy<String> ty = ApgTy.ApgTyL("old");
+      ApgTy<Integer> mapped = ty.map(label -> ApgTy.ApgTyL(label.length()));
+      assertEquals(3, mapped.l);
+    }
+
+    @Test
+    void mapPreservesBase() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Int");
+      ApgTy<Integer> mapped = ty.map(label -> ApgTy.ApgTyL(label.length()));
+      assertEquals("Int", mapped.b);
+      assertNull(mapped.l);
+    }
+
+    @Test
+    void mapTransformsProduct() {
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("f", ApgTy.ApgTyL("lbl"));
+      ApgTy<String> ty = ApgTy.ApgTyP(true, fields);
+      ApgTy<String> mapped = ty.map(label -> ApgTy.ApgTyL(label.toUpperCase()));
+      assertNotNull(mapped.m);
+      assertTrue(mapped.all);
+      assertEquals("LBL", mapped.m.get("f").l);
+    }
+  }
+
+  @Nested
+  class ValidateTest {
+
+    private ApgSchema<String> createSchema(Map<String, ApgTy<String>> schemaMap) {
+      ApgTypeside typeside = new ApgTypeside(Collections.emptyMap(), Collections.emptyMap());
+      return new ApgSchema<>(typeside, schemaMap);
+    }
+
+    @Test
+    void validateSucceedsForValidLabel() {
+      Map<String, ApgTy<String>> schemaMap = new HashMap<>();
+      schemaMap.put("Person", ApgTy.ApgTyB("String"));
+      ApgSchema<String> schema = createSchema(schemaMap);
+
+      ApgTy<String> ty = ApgTy.ApgTyL("Person");
+      ty.validate(schema); // should not throw
+    }
+
+    @Test
+    void validateThrowsForInvalidLabel() {
+      Map<String, ApgTy<String>> schemaMap = new HashMap<>();
+      ApgSchema<String> schema = createSchema(schemaMap);
+
+      ApgTy<String> ty = ApgTy.ApgTyL("Missing");
+      assertThrows(RuntimeException.class, () -> ty.validate(schema));
+    }
+
+    @Test
+    void validateRecursesIntoFields() {
+      Map<String, ApgTy<String>> schemaMap = new HashMap<>();
+      schemaMap.put("Name", ApgTy.ApgTyB("String"));
+      ApgSchema<String> schema = createSchema(schemaMap);
+
+      Map<String, ApgTy<String>> fields = new HashMap<>();
+      fields.put("name", ApgTy.ApgTyL("Name"));
+      ApgTy<String> product = ApgTy.ApgTyP(true, fields);
+      product.validate(schema); // should not throw, "Name" exists in schema
+
+      // Now with invalid nested label
+      Map<String, ApgTy<String>> badFields = new HashMap<>();
+      badFields.put("missing", ApgTy.ApgTyL("NoSuchLabel"));
+      ApgTy<String> badProduct = ApgTy.ApgTyP(true, badFields);
+      assertThrows(RuntimeException.class, () -> badProduct.validate(schema));
+    }
+  }
+}

--- a/src/catdata/apg/ApgTypesideTest.java
+++ b/src/catdata/apg/ApgTypesideTest.java
@@ -1,0 +1,139 @@
+package catdata.apg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import catdata.Pair;
+import catdata.Triple;
+import catdata.cql.Kind;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTypesideTest {
+
+  private static final Map<String, Pair<Class<?>, Function<String, Object>>> EMPTY_BS =
+      Collections.emptyMap();
+
+  private static final Map<String, Triple<List<String>, String, Function<List<Object>, Object>>> EMPTY_UDFS =
+      Collections.emptyMap();
+
+  private ApgTypeside createEmpty() {
+    return new ApgTypeside(EMPTY_BS, EMPTY_UDFS);
+  }
+
+  private ApgTypeside createWithOneType() {
+    Map<String, Pair<Class<?>, Function<String, Object>>> bs =
+        Map.of("Int", new Pair<>(Integer.class, Integer::parseInt));
+    return new ApgTypeside(bs, EMPTY_UDFS);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsFields() {
+      Map<String, Pair<Class<?>, Function<String, Object>>> bs =
+          Map.of("Int", new Pair<>(Integer.class, Integer::parseInt));
+      Map<String, Triple<List<String>, String, Function<List<Object>, Object>>> udfs =
+          Map.of("add", new Triple<>(List.of("Int", "Int"), "Int", args -> args.get(0)));
+      ApgTypeside ts = new ApgTypeside(bs, udfs);
+      assertNotNull(ts.Bs);
+      assertNotNull(ts.udfs);
+      assertEquals(1, ts.Bs.size());
+      assertTrue(ts.Bs.containsKey("Int"));
+      assertEquals(1, ts.udfs.size());
+      assertTrue(ts.udfs.containsKey("add"));
+    }
+  }
+
+  @Nested
+  class KindTest {
+
+    @Test
+    void kindReturnsApgTypeside() {
+      ApgTypeside ts = createEmpty();
+      assertEquals(Kind.APG_typeside, ts.kind());
+    }
+  }
+
+  @Nested
+  class SizeTest {
+
+    @Test
+    void sizeReturnsSumOfBsAndUdfs() {
+      Map<String, Pair<Class<?>, Function<String, Object>>> bs =
+          Map.of("Int", new Pair<>(Integer.class, Integer::parseInt));
+      Map<String, Triple<List<String>, String, Function<List<Object>, Object>>> udfs =
+          Map.of("add", new Triple<>(List.of("Int", "Int"), "Int", args -> args.get(0)),
+              "sub", new Triple<>(List.of("Int", "Int"), "Int", args -> args.get(0)));
+      ApgTypeside ts = new ApgTypeside(bs, udfs);
+      assertEquals(3, ts.size());
+    }
+
+    @Test
+    void sizeEmptyReturnsZero() {
+      ApgTypeside ts = createEmpty();
+      assertEquals(0, ts.size());
+    }
+  }
+
+  @Nested
+  class EqualsHashCode {
+
+    @Test
+    void equalsSame() {
+      ApgTypeside ts1 = createEmpty();
+      ApgTypeside ts2 = createEmpty();
+      assertEquals(ts1, ts2);
+    }
+
+    @Test
+    void notEqualsDifferentBs() {
+      ApgTypeside ts1 = createEmpty();
+      ApgTypeside ts2 = createWithOneType();
+      assertNotEquals(ts1, ts2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgTypeside ts = createEmpty();
+      assertEquals(ts, ts);
+    }
+
+    @Test
+    void notEqualsNull() {
+      ApgTypeside ts = createEmpty();
+      assertNotEquals(null, ts);
+    }
+
+    @Test
+    void notEqualsDifferentType() {
+      ApgTypeside ts = createEmpty();
+      assertNotEquals("not a typeside", ts);
+    }
+
+    @Test
+    void hashCodeConsistent() {
+      ApgTypeside ts1 = createEmpty();
+      ApgTypeside ts2 = createEmpty();
+      assertEquals(ts1.hashCode(), ts2.hashCode());
+    }
+  }
+
+  @Nested
+  class ToStringTest {
+
+    @Test
+    void toStringContainsTypeInfo() {
+      ApgTypeside ts = createWithOneType();
+      String str = ts.toString();
+      assertTrue(str.contains("Int"));
+    }
+  }
+}

--- a/src/catdata/apg/exp/ApgInstExpTest.java
+++ b/src/catdata/apg/exp/ApgInstExpTest.java
@@ -1,0 +1,404 @@
+package catdata.apg.exp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import catdata.Pair;
+import catdata.Unit;
+import catdata.apg.exp.ApgInstExp.ApgInstExpCoEqualize;
+import catdata.apg.exp.ApgInstExp.ApgInstExpDelta;
+import catdata.apg.exp.ApgInstExp.ApgInstExpEqualize;
+import catdata.apg.exp.ApgInstExp.ApgInstExpInitial;
+import catdata.apg.exp.ApgInstExp.ApgInstExpPlus;
+import catdata.apg.exp.ApgInstExp.ApgInstExpTerminal;
+import catdata.apg.exp.ApgInstExp.ApgInstExpTimes;
+import catdata.apg.exp.ApgInstExp.ApgInstExpVar;
+import catdata.apg.exp.ApgMapExp.ApgMapExpVar;
+import catdata.apg.exp.ApgSchExp.ApgSchExpVar;
+import catdata.apg.exp.ApgTransExp.ApgTransExpVar;
+import catdata.apg.exp.ApgTyExp.ApgTyExpVar;
+import catdata.cql.Kind;
+import catdata.cql.exp.AqlTyping;
+import java.util.Collection;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgInstExpTest {
+
+  @Nested
+  class ApgInstExpVarTest {
+
+    @Test
+    void constructorSetsVar() {
+      assertEquals("i1", new ApgInstExpVar("i1").var);
+    }
+
+    @Test
+    void kindReturnsApgInstance() {
+      assertEquals(Kind.APG_instance, new ApgInstExpVar("i").kind());
+    }
+
+    @Test
+    void isVarReturnsTrue() {
+      assertTrue(new ApgInstExpVar("i").isVar());
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      assertEquals("myInst", new ApgInstExpVar("myInst").toString());
+    }
+
+    @Test
+    void depsReturnsSingleton() {
+      Collection<Pair<String, Kind>> deps = new ApgInstExpVar("i1").deps();
+      assertEquals(1, deps.size());
+      Pair<String, Kind> dep = deps.iterator().next();
+      assertEquals("i1", dep.first);
+      assertEquals(Kind.APG_instance, dep.second);
+    }
+
+    @Test
+    void equalsSameVar() {
+      ApgInstExpVar v1 = new ApgInstExpVar("i");
+      ApgInstExpVar v2 = new ApgInstExpVar("i");
+      assertEquals(v1, v2);
+      assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentVar() {
+      assertNotEquals(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgInstExpVar v = new ApgInstExpVar("i");
+      assertEquals(v, v);
+    }
+
+    @Test
+    void notEqualsNull() {
+      assertNotEquals(null, new ApgInstExpVar("i"));
+    }
+
+    @Test
+    void typeThrowsWhenUndefined() {
+      AqlTyping typing = new AqlTyping();
+      assertThrows(RuntimeException.class, () -> new ApgInstExpVar("missing").type(typing));
+    }
+
+    @Test
+    void typeReturnsSchExpWhenDefined() {
+      AqlTyping typing = new AqlTyping();
+      ApgSchExpVar schExp = new ApgSchExpVar("s1");
+      typing.defs.apgis.put("i1", schExp);
+      assertEquals(schExp, new ApgInstExpVar("i1").type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() throws Exception {
+      ApgInstExpVar v = new ApgInstExpVar("i");
+      @SuppressWarnings("unchecked")
+      ApgInstExp.ApgInstExpVisitor<String, Void, RuntimeException> visitor =
+          mock(ApgInstExp.ApgInstExpVisitor.class);
+      v.accept(null, visitor);
+      verify(visitor).visit(null, v);
+    }
+
+    @Test
+    void varMethodCreatesNew() {
+      var newVar = new ApgInstExpVar("i1").Var("i2");
+      assertTrue(newVar instanceof ApgInstExpVar);
+      assertEquals("i2", ((ApgInstExpVar) newVar).var);
+    }
+  }
+
+  @Nested
+  class ApgInstExpInitialTest {
+
+    @Test
+    void constructorSetsTypeside() {
+      ApgSchExpVar sch = new ApgSchExpVar("s");
+      ApgInstExpInitial init = new ApgInstExpInitial(sch);
+      assertEquals(sch, init.typeside);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpInitial i1 = new ApgInstExpInitial(new ApgSchExpVar("s"));
+      ApgInstExpInitial i2 = new ApgInstExpInitial(new ApgSchExpVar("s"));
+      assertEquals(i1, i2);
+      assertEquals(i1.hashCode(), i2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferent() {
+      assertNotEquals(
+          new ApgInstExpInitial(new ApgSchExpVar("a")),
+          new ApgInstExpInitial(new ApgSchExpVar("b")));
+    }
+
+    @Test
+    void toStringContainsEmpty() {
+      assertTrue(new ApgInstExpInitial(new ApgSchExpVar("s")).toString().contains("empty"));
+    }
+
+    @Test
+    void typeReturnsTypeside() {
+      AqlTyping typing = new AqlTyping();
+      ApgTyExpVar tyExp = new ApgTyExpVar("ts");
+      typing.defs.apgschemas.put("s", tyExp);
+      ApgSchExpVar sch = new ApgSchExpVar("s");
+      assertEquals(sch, new ApgInstExpInitial(sch).type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() throws Exception {
+      ApgInstExpInitial init = new ApgInstExpInitial(new ApgSchExpVar("s"));
+      @SuppressWarnings("unchecked")
+      ApgInstExp.ApgInstExpVisitor<String, Void, RuntimeException> visitor =
+          mock(ApgInstExp.ApgInstExpVisitor.class);
+      init.accept(null, visitor);
+      verify(visitor).visit(null, init);
+    }
+  }
+
+  @Nested
+  class ApgInstExpTerminalTest {
+
+    @Test
+    void constructorSetsTypeside() {
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      ApgInstExpTerminal term = new ApgInstExpTerminal(ts);
+      assertEquals(ts, term.typeside);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpTerminal t1 = new ApgInstExpTerminal(new ApgTyExpVar("ts"));
+      ApgInstExpTerminal t2 = new ApgInstExpTerminal(new ApgTyExpVar("ts"));
+      assertEquals(t1, t2);
+    }
+
+    @Test
+    void toStringContainsUnit() {
+      assertTrue(new ApgInstExpTerminal(new ApgTyExpVar("ts")).toString().contains("unit"));
+    }
+
+    @Test
+    void typeReturnsSchExpTerminal() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      ApgSchExp result = new ApgInstExpTerminal(ts).type(typing);
+      assertTrue(result instanceof ApgSchExp.ApgSchExpTerminal);
+    }
+  }
+
+  @Nested
+  class ApgInstExpTimesTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgInstExpVar l = new ApgInstExpVar("i1");
+      ApgInstExpVar r = new ApgInstExpVar("i2");
+      ApgInstExpTimes times = new ApgInstExpTimes(l, r);
+      assertEquals(l, times.l);
+      assertEquals(r, times.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpTimes t1 = new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      ApgInstExpTimes t2 = new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      assertEquals(t1, t2);
+      assertEquals(t1.hashCode(), t2.hashCode());
+    }
+
+    @Test
+    void notEqualsSwapped() {
+      assertNotEquals(
+          new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b")),
+          new ApgInstExpTimes(new ApgInstExpVar("b"), new ApgInstExpVar("a")));
+    }
+
+    @Test
+    void toStringContainsStar() {
+      assertTrue(
+          new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("*"));
+    }
+
+    @Test
+    void depsUnionsBoth() {
+      ApgInstExpTimes times =
+          new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      assertEquals(2, times.deps().size());
+    }
+
+    @Test
+    void typeThrowsOnDifferentTypesides() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts1", Unit.unit);
+      typing.defs.apgts.put("ts2", Unit.unit);
+      typing.defs.apgschemas.put("s1", new ApgTyExpVar("ts1"));
+      typing.defs.apgschemas.put("s2", new ApgTyExpVar("ts2"));
+      typing.defs.apgis.put("a", new ApgSchExpVar("s1"));
+      typing.defs.apgis.put("b", new ApgSchExpVar("s2"));
+      ApgInstExpTimes times = new ApgInstExpTimes(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      assertThrows(RuntimeException.class, () -> times.type(typing));
+    }
+  }
+
+  @Nested
+  class ApgInstExpPlusTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgInstExpVar l = new ApgInstExpVar("i1");
+      ApgInstExpVar r = new ApgInstExpVar("i2");
+      ApgInstExpPlus plus = new ApgInstExpPlus(l, r);
+      assertEquals(l, plus.l);
+      assertEquals(r, plus.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpPlus p1 = new ApgInstExpPlus(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      ApgInstExpPlus p2 = new ApgInstExpPlus(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      assertEquals(p1, p2);
+      assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void toStringContainsPlus() {
+      assertTrue(
+          new ApgInstExpPlus(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("+"));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() throws Exception {
+      ApgInstExpPlus plus = new ApgInstExpPlus(new ApgInstExpVar("a"), new ApgInstExpVar("b"));
+      @SuppressWarnings("unchecked")
+      ApgInstExp.ApgInstExpVisitor<String, Void, RuntimeException> visitor =
+          mock(ApgInstExp.ApgInstExpVisitor.class);
+      plus.accept(null, visitor);
+      verify(visitor).visit(null, plus);
+    }
+  }
+
+  @Nested
+  class ApgInstExpEqualizeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar l = new ApgTransExpVar("t1");
+      ApgTransExpVar r = new ApgTransExpVar("t2");
+      ApgInstExpEqualize eq = new ApgInstExpEqualize(l, r);
+      assertEquals(l, eq.l);
+      assertEquals(r, eq.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpEqualize e1 =
+          new ApgInstExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"));
+      ApgInstExpEqualize e2 =
+          new ApgInstExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"));
+      assertEquals(e1, e2);
+      assertEquals(e1.hashCode(), e2.hashCode());
+    }
+
+    @Test
+    void toStringContainsEqualize() {
+      assertTrue(
+          new ApgInstExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+              .toString()
+              .contains("equalize"));
+    }
+
+    @Test
+    void depsUnionsBoth() {
+      ApgInstExpEqualize eq =
+          new ApgInstExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"));
+      assertEquals(2, eq.deps().size());
+    }
+  }
+
+  @Nested
+  class ApgInstExpCoEqualizeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar l = new ApgTransExpVar("t1");
+      ApgTransExpVar r = new ApgTransExpVar("t2");
+      ApgInstExpCoEqualize ceq = new ApgInstExpCoEqualize(l, r);
+      assertEquals(l, ceq.l);
+      assertEquals(r, ceq.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpCoEqualize c1 =
+          new ApgInstExpCoEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"));
+      ApgInstExpCoEqualize c2 =
+          new ApgInstExpCoEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"));
+      assertEquals(c1, c2);
+    }
+
+    @Test
+    void toStringContainsCoequalize() {
+      assertTrue(
+          new ApgInstExpCoEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+              .toString()
+              .contains("coequalize"));
+    }
+  }
+
+  @Nested
+  class ApgInstExpDeltaTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgMapExpVar f = new ApgMapExpVar("m");
+      ApgInstExpVar j = new ApgInstExpVar("i");
+      ApgInstExpDelta delta = new ApgInstExpDelta(f, j);
+      assertEquals(f, delta.F);
+      assertEquals(j, delta.J);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgInstExpDelta d1 = new ApgInstExpDelta(new ApgMapExpVar("m"), new ApgInstExpVar("i"));
+      ApgInstExpDelta d2 = new ApgInstExpDelta(new ApgMapExpVar("m"), new ApgInstExpVar("i"));
+      assertEquals(d1, d2);
+      assertEquals(d1.hashCode(), d2.hashCode());
+    }
+
+    @Test
+    void toStringContainsDelta() {
+      assertTrue(
+          new ApgInstExpDelta(new ApgMapExpVar("m"), new ApgInstExpVar("i"))
+              .toString()
+              .contains("delta"));
+    }
+
+    @Test
+    void depsUnionsBoth() {
+      ApgInstExpDelta delta = new ApgInstExpDelta(new ApgMapExpVar("m"), new ApgInstExpVar("i"));
+      assertEquals(2, delta.deps().size());
+    }
+  }
+
+  @Test
+  void optionsReturnsEmptyMap() {
+    assertTrue(new ApgInstExpVar("x").options().isEmpty());
+  }
+}

--- a/src/catdata/apg/exp/ApgMapExpTest.java
+++ b/src/catdata/apg/exp/ApgMapExpTest.java
@@ -1,0 +1,215 @@
+package catdata.apg.exp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import catdata.Pair;
+import catdata.Unit;
+import catdata.apg.exp.ApgMapExp.ApgMapExpCompose;
+import catdata.apg.exp.ApgMapExp.ApgMapExpVar;
+import catdata.apg.exp.ApgSchExp.ApgSchExpVar;
+import catdata.apg.exp.ApgTyExp.ApgTyExpVar;
+import catdata.cql.Kind;
+import catdata.cql.exp.AqlTyping;
+import java.util.Collection;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgMapExpTest {
+
+  @Nested
+  class ApgMapExpVarTest {
+
+    @Test
+    void constructorSetsVar() {
+      assertEquals("m1", new ApgMapExpVar("m1").var);
+    }
+
+    @Test
+    void kindReturnsApgMapping() {
+      assertEquals(Kind.APG_mapping, new ApgMapExpVar("m").kind());
+    }
+
+    @Test
+    void isVarReturnsTrue() {
+      assertTrue(new ApgMapExpVar("m").isVar());
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      assertEquals("myMap", new ApgMapExpVar("myMap").toString());
+    }
+
+    @Test
+    void depsReturnsSingleton() {
+      Collection<Pair<String, Kind>> deps = new ApgMapExpVar("m1").deps();
+      assertEquals(1, deps.size());
+      Pair<String, Kind> dep = deps.iterator().next();
+      assertEquals("m1", dep.first);
+      assertEquals(Kind.APG_instance, dep.second);
+    }
+
+    @Test
+    void equalsSameVar() {
+      ApgMapExpVar v1 = new ApgMapExpVar("m");
+      ApgMapExpVar v2 = new ApgMapExpVar("m");
+      assertEquals(v1, v2);
+      assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentVar() {
+      assertNotEquals(new ApgMapExpVar("a"), new ApgMapExpVar("b"));
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgMapExpVar v = new ApgMapExpVar("m");
+      assertEquals(v, v);
+    }
+
+    @Test
+    void notEqualsNull() {
+      assertNotEquals(null, new ApgMapExpVar("m"));
+    }
+
+    @Test
+    void notEqualsDifferentType() {
+      assertNotEquals("m", new ApgMapExpVar("m"));
+    }
+
+    @Test
+    void typeThrowsWhenUndefined() {
+      AqlTyping typing = new AqlTyping();
+      assertThrows(RuntimeException.class, () -> new ApgMapExpVar("missing").type(typing));
+    }
+
+    @Test
+    void typeReturnsPairWhenDefined() {
+      AqlTyping typing = new AqlTyping();
+      Pair<ApgSchExp, ApgSchExp> pair =
+          new Pair<>(new ApgSchExpVar("s1"), new ApgSchExpVar("s2"));
+      typing.defs.apgmappings.put("m1", pair);
+      assertEquals(pair, new ApgMapExpVar("m1").type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgMapExpVar v = new ApgMapExpVar("m");
+      @SuppressWarnings("unchecked")
+      ApgMapExp.ApgMapExpVisitor<String, Void> visitor = mock(ApgMapExp.ApgMapExpVisitor.class);
+      v.accept(null, visitor);
+      verify(visitor).visit(null, v);
+    }
+
+    @Test
+    void coAcceptDelegatesToCoVisitor() {
+      ApgMapExpVar v = new ApgMapExpVar("m");
+      @SuppressWarnings("unchecked")
+      ApgMapExp.ApgMapExpCoVisitor<String, Void> coVisitor =
+          mock(ApgMapExp.ApgMapExpCoVisitor.class);
+      v.coaccept(null, coVisitor, "r");
+      verify(coVisitor).visitApgMapExpVar(null, "r");
+    }
+
+    @Test
+    void varMethodCreatesNew() {
+      var newVar = new ApgMapExpVar("m1").Var("m2");
+      assertTrue(newVar instanceof ApgMapExpVar);
+      assertEquals("m2", ((ApgMapExpVar) newVar).var);
+    }
+  }
+
+  @Nested
+  class ApgMapExpComposeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgMapExpVar h1 = new ApgMapExpVar("m1");
+      ApgMapExpVar h2 = new ApgMapExpVar("m2");
+      ApgMapExpCompose compose = new ApgMapExpCompose(h1, h2);
+      assertEquals(h1, compose.h1);
+      assertEquals(h2, compose.h2);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgMapExpCompose c1 = new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b"));
+      ApgMapExpCompose c2 = new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b"));
+      assertEquals(c1, c2);
+      assertEquals(c1.hashCode(), c2.hashCode());
+    }
+
+    @Test
+    void notEqualsSwapped() {
+      assertNotEquals(
+          new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b")),
+          new ApgMapExpCompose(new ApgMapExpVar("b"), new ApgMapExpVar("a")));
+    }
+
+    @Test
+    void toStringContainsSemicolon() {
+      String s = new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b")).toString();
+      assertTrue(s.contains(";"));
+    }
+
+    @Test
+    void depsUnionsBoth() {
+      ApgMapExpCompose compose =
+          new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b"));
+      assertEquals(2, compose.deps().size());
+    }
+
+    @Test
+    void acceptReturnsNull() {
+      // ApgMapExpCompose.accept returns null (commented-out delegation)
+      ApgMapExpCompose compose =
+          new ApgMapExpCompose(new ApgMapExpVar("a"), new ApgMapExpVar("b"));
+      @SuppressWarnings("unchecked")
+      ApgMapExp.ApgMapExpVisitor<String, Void> visitor = mock(ApgMapExp.ApgMapExpVisitor.class);
+      assertNull(compose.accept(null, visitor));
+    }
+
+    @Test
+    void typeThrowsOnIntermediateMismatch() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      typing.defs.apgschemas.put("s1", new ApgTyExpVar("ts"));
+      typing.defs.apgschemas.put("s2", new ApgTyExpVar("ts"));
+      typing.defs.apgschemas.put("s3", new ApgTyExpVar("ts"));
+      typing.defs.apgmappings.put(
+          "m1", new Pair<>(new ApgSchExpVar("s1"), new ApgSchExpVar("s2")));
+      typing.defs.apgmappings.put(
+          "m2", new Pair<>(new ApgSchExpVar("s3"), new ApgSchExpVar("s1")));
+      ApgMapExpCompose compose = new ApgMapExpCompose(new ApgMapExpVar("m1"), new ApgMapExpVar("m2"));
+      assertThrows(RuntimeException.class, () -> compose.type(typing));
+    }
+
+    @Test
+    void typeSucceedsOnMatchingIntermediate() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      typing.defs.apgschemas.put("s1", new ApgTyExpVar("ts"));
+      typing.defs.apgschemas.put("s2", new ApgTyExpVar("ts"));
+      typing.defs.apgschemas.put("s3", new ApgTyExpVar("ts"));
+      typing.defs.apgmappings.put(
+          "m1", new Pair<>(new ApgSchExpVar("s1"), new ApgSchExpVar("s2")));
+      typing.defs.apgmappings.put(
+          "m2", new Pair<>(new ApgSchExpVar("s2"), new ApgSchExpVar("s3")));
+      ApgMapExpCompose compose = new ApgMapExpCompose(new ApgMapExpVar("m1"), new ApgMapExpVar("m2"));
+      Pair<ApgSchExp, ApgSchExp> result = compose.type(typing);
+      assertEquals(new ApgSchExpVar("s1"), result.first);
+      assertEquals(new ApgSchExpVar("s3"), result.second);
+    }
+  }
+
+  @Test
+  void optionsReturnsEmptyMap() {
+    assertTrue(new ApgMapExpVar("x").options().isEmpty());
+  }
+}

--- a/src/catdata/apg/exp/ApgSchExpTest.java
+++ b/src/catdata/apg/exp/ApgSchExpTest.java
@@ -1,0 +1,436 @@
+package catdata.apg.exp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import catdata.LocStr;
+import catdata.Pair;
+import catdata.Unit;
+import catdata.apg.ApgTy;
+import catdata.apg.exp.ApgSchExp.ApgSchExpInitial;
+import catdata.apg.exp.ApgSchExp.ApgSchExpPlus;
+import catdata.apg.exp.ApgSchExp.ApgSchExpRaw;
+import catdata.apg.exp.ApgSchExp.ApgSchExpTerminal;
+import catdata.apg.exp.ApgSchExp.ApgSchExpTimes;
+import catdata.apg.exp.ApgSchExp.ApgSchExpVar;
+import catdata.apg.exp.ApgTyExp.ApgTyExpVar;
+import catdata.cql.Kind;
+import catdata.cql.exp.AqlTyping;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgSchExpTest {
+
+  @Nested
+  class ApgSchExpVarTest {
+
+    @Test
+    void constructorSetsVar() {
+      ApgSchExpVar v = new ApgSchExpVar("s1");
+      assertEquals("s1", v.var);
+    }
+
+    @Test
+    void kindReturnsApgSchema() {
+      ApgSchExpVar v = new ApgSchExpVar("s");
+      assertEquals(Kind.APG_schema, v.kind());
+    }
+
+    @Test
+    void isVarReturnsTrue() {
+      assertTrue(new ApgSchExpVar("s").isVar());
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      assertEquals("mySchema", new ApgSchExpVar("mySchema").toString());
+    }
+
+    @Test
+    void depsReturnsSingleton() {
+      Collection<Pair<String, Kind>> deps = new ApgSchExpVar("s1").deps();
+      assertEquals(1, deps.size());
+      Pair<String, Kind> dep = deps.iterator().next();
+      assertEquals("s1", dep.first);
+      assertEquals(Kind.APG_instance, dep.second);
+    }
+
+    @Test
+    void equalsSameVar() {
+      ApgSchExpVar v1 = new ApgSchExpVar("s");
+      ApgSchExpVar v2 = new ApgSchExpVar("s");
+      assertEquals(v1, v2);
+      assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentVar() {
+      assertNotEquals(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgSchExpVar v = new ApgSchExpVar("s");
+      assertEquals(v, v);
+    }
+
+    @Test
+    void notEqualsNull() {
+      assertNotEquals(null, new ApgSchExpVar("s"));
+    }
+
+    @Test
+    void notEqualsDifferentType() {
+      assertNotEquals("s", new ApgSchExpVar("s"));
+    }
+
+    @Test
+    void typeThrowsWhenUndefined() {
+      AqlTyping typing = new AqlTyping();
+      assertThrows(RuntimeException.class, () -> new ApgSchExpVar("missing").type(typing));
+    }
+
+    @Test
+    void typeReturnsExpWhenDefined() {
+      AqlTyping typing = new AqlTyping();
+      ApgTyExpVar tyExp = new ApgTyExpVar("ts1");
+      typing.defs.apgschemas.put("s1", tyExp);
+      ApgTyExp result = new ApgSchExpVar("s1").type(typing);
+      assertEquals(tyExp, result);
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgSchExpVar v = new ApgSchExpVar("s");
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpVisitor<String, Void> visitor = mock(ApgSchExp.ApgSchExpVisitor.class);
+      v.accept(null, visitor);
+      verify(visitor).visit(null, v);
+    }
+
+    @Test
+    void coAcceptDelegatesToCoVisitor() {
+      ApgSchExpVar v = new ApgSchExpVar("s");
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpCoVisitor<String, Void> coVisitor =
+          mock(ApgSchExp.ApgSchExpCoVisitor.class);
+      v.coaccept(null, coVisitor, "r");
+      verify(coVisitor).visitApgSchExpVar(null, "r");
+    }
+
+    @Test
+    void varMethodCreatesNewSchExpVar() {
+      ApgSchExpVar v = new ApgSchExpVar("s1");
+      var newVar = v.Var("s2");
+      assertTrue(newVar instanceof ApgSchExpVar);
+      assertEquals("s2", ((ApgSchExpVar) newVar).var);
+    }
+  }
+
+  @Nested
+  class ApgSchExpRawTest {
+
+    private ApgSchExpRaw createEmptyRaw() {
+      return new ApgSchExpRaw(
+          new ApgTyExpVar("ts"), Collections.emptyList(), Collections.emptyList());
+    }
+
+    @Test
+    void constructorSetsFields() {
+      ApgSchExpRaw raw = createEmptyRaw();
+      assertNotNull(raw.typeside);
+      assertNotNull(raw.imports);
+      assertNotNull(raw.Ls);
+      assertTrue(raw.imports.isEmpty());
+      assertTrue(raw.Ls.isEmpty());
+    }
+
+    @Test
+    void constructorWithLabels() {
+      ApgTy<String> ty = ApgTy.ApgTyB("Int");
+      List<Pair<LocStr, ApgTy<String>>> labels =
+          List.of(new Pair<>(new LocStr(0, "age"), ty));
+      ApgSchExpRaw raw = new ApgSchExpRaw(new ApgTyExpVar("ts"), Collections.emptyList(), labels);
+      assertEquals(1, raw.Ls.size());
+      assertTrue(raw.Ls.containsKey("age"));
+    }
+
+    @Test
+    void depsIncludesTypesideDeps() {
+      ApgSchExpRaw raw = createEmptyRaw();
+      Collection<Pair<String, Kind>> deps = raw.deps();
+      assertEquals(1, deps.size());
+      assertEquals("ts", deps.iterator().next().first);
+    }
+
+    @Test
+    void equalsSameContent() {
+      ApgSchExpRaw r1 = createEmptyRaw();
+      ApgSchExpRaw r2 = createEmptyRaw();
+      assertEquals(r1, r2);
+      assertEquals(r1.hashCode(), r2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentTypeside() {
+      ApgSchExpRaw r1 = createEmptyRaw();
+      ApgSchExpRaw r2 =
+          new ApgSchExpRaw(
+              new ApgTyExpVar("other"), Collections.emptyList(), Collections.emptyList());
+      assertNotEquals(r1, r2);
+    }
+
+    @Test
+    void toStringContainsLiteral() {
+      assertTrue(createEmptyRaw().toString().contains("literal"));
+    }
+
+    @Test
+    void rawReturnsNonNull() {
+      assertNotNull(createEmptyRaw().raw());
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgSchExpRaw raw = createEmptyRaw();
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpVisitor<String, Void> visitor = mock(ApgSchExp.ApgSchExpVisitor.class);
+      raw.accept(null, visitor);
+      verify(visitor).visit(null, raw);
+    }
+
+    @Test
+    void typeReturnsTypeside() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      ApgSchExpRaw raw = createEmptyRaw();
+      ApgTyExp result = raw.type(typing);
+      assertEquals(new ApgTyExpVar("ts"), result);
+    }
+
+    @Test
+    void isVarReturnsFalse() {
+      assertFalse(createEmptyRaw().isVar());
+    }
+  }
+
+  @Nested
+  class ApgSchExpInitialTest {
+
+    @Test
+    void constructorSetsTypeside() {
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      ApgSchExpInitial init = new ApgSchExpInitial(ts);
+      assertEquals(ts, init.typeside);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgSchExpInitial i1 = new ApgSchExpInitial(new ApgTyExpVar("ts"));
+      ApgSchExpInitial i2 = new ApgSchExpInitial(new ApgTyExpVar("ts"));
+      assertEquals(i1, i2);
+      assertEquals(i1.hashCode(), i2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferent() {
+      assertNotEquals(
+          new ApgSchExpInitial(new ApgTyExpVar("a")),
+          new ApgSchExpInitial(new ApgTyExpVar("b")));
+    }
+
+    @Test
+    void toStringContainsEmpty() {
+      assertTrue(new ApgSchExpInitial(new ApgTyExpVar("ts")).toString().contains("empty"));
+    }
+
+    @Test
+    void depsMatchesTypesideDeps() {
+      ApgSchExpInitial init = new ApgSchExpInitial(new ApgTyExpVar("ts"));
+      assertEquals(new ApgTyExpVar("ts").deps(), init.deps());
+    }
+
+    @Test
+    void typeReturnsTypeside() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      ApgSchExpInitial init = new ApgSchExpInitial(ts);
+      assertEquals(ts, init.type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgSchExpInitial init = new ApgSchExpInitial(new ApgTyExpVar("ts"));
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpVisitor<String, Void> visitor = mock(ApgSchExp.ApgSchExpVisitor.class);
+      init.accept(null, visitor);
+      verify(visitor).visit(null, init);
+    }
+  }
+
+  @Nested
+  class ApgSchExpTerminalTest {
+
+    @Test
+    void constructorSetsTypeside() {
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      ApgSchExpTerminal term = new ApgSchExpTerminal(ts);
+      assertEquals(ts, term.typeside);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgSchExpTerminal t1 = new ApgSchExpTerminal(new ApgTyExpVar("ts"));
+      ApgSchExpTerminal t2 = new ApgSchExpTerminal(new ApgTyExpVar("ts"));
+      assertEquals(t1, t2);
+    }
+
+    @Test
+    void toStringContainsUnit() {
+      assertTrue(new ApgSchExpTerminal(new ApgTyExpVar("ts")).toString().contains("unit"));
+    }
+
+    @Test
+    void typeReturnsTypeside() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      ApgTyExpVar ts = new ApgTyExpVar("ts");
+      assertEquals(ts, new ApgSchExpTerminal(ts).type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgSchExpTerminal term = new ApgSchExpTerminal(new ApgTyExpVar("ts"));
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpVisitor<String, Void> visitor = mock(ApgSchExp.ApgSchExpVisitor.class);
+      term.accept(null, visitor);
+      verify(visitor).visit(null, term);
+    }
+  }
+
+  @Nested
+  class ApgSchExpTimesTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgSchExpVar l = new ApgSchExpVar("s1");
+      ApgSchExpVar r = new ApgSchExpVar("s2");
+      ApgSchExpTimes times = new ApgSchExpTimes(l, r);
+      assertEquals(l, times.l);
+      assertEquals(r, times.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgSchExpTimes t1 = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      ApgSchExpTimes t2 = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      assertEquals(t1, t2);
+      assertEquals(t1.hashCode(), t2.hashCode());
+    }
+
+    @Test
+    void notEqualsSwapped() {
+      ApgSchExpTimes t1 = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      ApgSchExpTimes t2 = new ApgSchExpTimes(new ApgSchExpVar("b"), new ApgSchExpVar("a"));
+      assertNotEquals(t1, t2);
+    }
+
+    @Test
+    void toStringContainsStar() {
+      String s = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b")).toString();
+      assertTrue(s.contains("*"));
+    }
+
+    @Test
+    void depsUnionsBothSides() {
+      ApgSchExpTimes times =
+          new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      Collection<Pair<String, Kind>> deps = times.deps();
+      assertEquals(2, deps.size());
+    }
+
+    @Test
+    void typeThrowsOnDifferentTypesides() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts1", Unit.unit);
+      typing.defs.apgts.put("ts2", Unit.unit);
+      typing.defs.apgschemas.put("a", new ApgTyExpVar("ts1"));
+      typing.defs.apgschemas.put("b", new ApgTyExpVar("ts2"));
+      ApgSchExpTimes times = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      assertThrows(RuntimeException.class, () -> times.type(typing));
+    }
+
+    @Test
+    void typeSucceedsWithSameTypeside() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts", Unit.unit);
+      typing.defs.apgschemas.put("a", new ApgTyExpVar("ts"));
+      typing.defs.apgschemas.put("b", new ApgTyExpVar("ts"));
+      ApgSchExpTimes times = new ApgSchExpTimes(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      ApgTyExp result = times.type(typing);
+      assertEquals(new ApgTyExpVar("ts"), result);
+    }
+  }
+
+  @Nested
+  class ApgSchExpPlusTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgSchExpVar l = new ApgSchExpVar("s1");
+      ApgSchExpVar r = new ApgSchExpVar("s2");
+      ApgSchExpPlus plus = new ApgSchExpPlus(l, r);
+      assertEquals(l, plus.l);
+      assertEquals(r, plus.r);
+    }
+
+    @Test
+    void equalsSame() {
+      ApgSchExpPlus p1 = new ApgSchExpPlus(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      ApgSchExpPlus p2 = new ApgSchExpPlus(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      assertEquals(p1, p2);
+      assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    void toStringContainsPlus() {
+      String s = new ApgSchExpPlus(new ApgSchExpVar("a"), new ApgSchExpVar("b")).toString();
+      assertTrue(s.contains("+"));
+    }
+
+    @Test
+    void typeThrowsOnDifferentTypesides() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts1", Unit.unit);
+      typing.defs.apgts.put("ts2", Unit.unit);
+      typing.defs.apgschemas.put("a", new ApgTyExpVar("ts1"));
+      typing.defs.apgschemas.put("b", new ApgTyExpVar("ts2"));
+      ApgSchExpPlus plus = new ApgSchExpPlus(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      assertThrows(RuntimeException.class, () -> plus.type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgSchExpPlus plus = new ApgSchExpPlus(new ApgSchExpVar("a"), new ApgSchExpVar("b"));
+      @SuppressWarnings("unchecked")
+      ApgSchExp.ApgSchExpVisitor<String, Void> visitor = mock(ApgSchExp.ApgSchExpVisitor.class);
+      plus.accept(null, visitor);
+      verify(visitor).visit(null, plus);
+    }
+  }
+
+  @Test
+  void optionsReturnsEmptyMap() {
+    assertTrue(new ApgSchExpVar("x").options().isEmpty());
+  }
+}

--- a/src/catdata/apg/exp/ApgTransExpTest.java
+++ b/src/catdata/apg/exp/ApgTransExpTest.java
@@ -1,0 +1,640 @@
+package catdata.apg.exp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import catdata.Pair;
+import catdata.Unit;
+import catdata.apg.exp.ApgInstExp.ApgInstExpCoEqualize;
+import catdata.apg.exp.ApgInstExp.ApgInstExpEqualize;
+import catdata.apg.exp.ApgInstExp.ApgInstExpPlus;
+import catdata.apg.exp.ApgInstExp.ApgInstExpTimes;
+import catdata.apg.exp.ApgInstExp.ApgInstExpVar;
+import catdata.apg.exp.ApgMapExp.ApgMapExpVar;
+import catdata.apg.exp.ApgSchExp.ApgSchExpVar;
+import catdata.apg.exp.ApgTransExp.ApgTransExpCase;
+import catdata.apg.exp.ApgTransExp.ApgTransExpCoEqualize;
+import catdata.apg.exp.ApgTransExp.ApgTransExpCoEqualizeU;
+import catdata.apg.exp.ApgTransExp.ApgTransExpCompose;
+import catdata.apg.exp.ApgTransExp.ApgTransExpDelta;
+import catdata.apg.exp.ApgTransExp.ApgTransExpEqualize;
+import catdata.apg.exp.ApgTransExp.ApgTransExpEqualizeU;
+import catdata.apg.exp.ApgTransExp.ApgTransExpFst;
+import catdata.apg.exp.ApgTransExp.ApgTransExpId;
+import catdata.apg.exp.ApgTransExp.ApgTransExpInitial;
+import catdata.apg.exp.ApgTransExp.ApgTransExpInl;
+import catdata.apg.exp.ApgTransExp.ApgTransExpInr;
+import catdata.apg.exp.ApgTransExp.ApgTransExpPair;
+import catdata.apg.exp.ApgTransExp.ApgTransExpSnd;
+import catdata.apg.exp.ApgTransExp.ApgTransExpTerminal;
+import catdata.apg.exp.ApgTransExp.ApgTransExpVar;
+import catdata.apg.exp.ApgTyExp.ApgTyExpVar;
+import catdata.cql.Kind;
+import catdata.cql.exp.AqlTyping;
+import java.util.Collection;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTransExpTest {
+
+  private AqlTyping setupTypingWithInstances(String... instNames) {
+    AqlTyping typing = new AqlTyping();
+    typing.defs.apgts.put("ts", Unit.unit);
+    typing.defs.apgschemas.put("s", new ApgTyExpVar("ts"));
+    for (String name : instNames) {
+      typing.defs.apgis.put(name, new ApgSchExpVar("s"));
+    }
+    return typing;
+  }
+
+  private AqlTyping setupTypingWithTransforms(
+      String t1, String srcI1, String dstI1, String t2, String srcI2, String dstI2) {
+    AqlTyping typing = new AqlTyping();
+    typing.defs.apgts.put("ts", Unit.unit);
+    typing.defs.apgschemas.put("s", new ApgTyExpVar("ts"));
+    typing.defs.apgis.put(srcI1, new ApgSchExpVar("s"));
+    typing.defs.apgis.put(dstI1, new ApgSchExpVar("s"));
+    typing.defs.apgis.put(srcI2, new ApgSchExpVar("s"));
+    typing.defs.apgis.put(dstI2, new ApgSchExpVar("s"));
+    typing.defs.apgms.put(t1, new Pair<>(new ApgInstExpVar(srcI1), new ApgInstExpVar(dstI1)));
+    typing.defs.apgms.put(t2, new Pair<>(new ApgInstExpVar(srcI2), new ApgInstExpVar(dstI2)));
+    return typing;
+  }
+
+  @Nested
+  class ApgTransExpVarTest {
+
+    @Test
+    void constructorSetsVar() {
+      assertEquals("t1", new ApgTransExpVar("t1").var);
+    }
+
+    @Test
+    void kindReturnsApgMorphism() {
+      assertEquals(Kind.APG_morphism, new ApgTransExpVar("t").kind());
+    }
+
+    @Test
+    void isVarReturnsTrue() {
+      assertTrue(new ApgTransExpVar("t").isVar());
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      assertEquals("myTrans", new ApgTransExpVar("myTrans").toString());
+    }
+
+    @Test
+    void depsReturnsSingleton() {
+      Collection<Pair<String, Kind>> deps = new ApgTransExpVar("t1").deps();
+      assertEquals(1, deps.size());
+      assertEquals(Kind.APG_morphism, deps.iterator().next().second);
+    }
+
+    @Test
+    void equalsSameVar() {
+      assertEquals(new ApgTransExpVar("t"), new ApgTransExpVar("t"));
+      assertEquals(new ApgTransExpVar("t").hashCode(), new ApgTransExpVar("t").hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentVar() {
+      assertNotEquals(new ApgTransExpVar("a"), new ApgTransExpVar("b"));
+    }
+
+    @Test
+    void typeThrowsWhenUndefined() {
+      AqlTyping typing = new AqlTyping();
+      assertThrows(RuntimeException.class, () -> new ApgTransExpVar("missing").type(typing));
+    }
+
+    @Test
+    void typeReturnsPairWhenDefined() {
+      AqlTyping typing = new AqlTyping();
+      Pair<ApgInstExp, ApgInstExp> pair =
+          new Pair<>(new ApgInstExpVar("i1"), new ApgInstExpVar("i2"));
+      typing.defs.apgms.put("t1", pair);
+      assertEquals(pair, new ApgTransExpVar("t1").type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgTransExpVar v = new ApgTransExpVar("t");
+      @SuppressWarnings("unchecked")
+      ApgTransExp.ApgTransExpVisitor<String, Void> visitor =
+          mock(ApgTransExp.ApgTransExpVisitor.class);
+      v.accept(null, visitor);
+      verify(visitor).visit(null, v);
+    }
+
+    @Test
+    void varMethodCreatesNew() {
+      var newVar = new ApgTransExpVar("t1").Var("t2");
+      assertTrue(newVar instanceof ApgTransExpVar);
+    }
+  }
+
+  @Nested
+  class ApgTransExpIdTest {
+
+    @Test
+    void constructorSetsField() {
+      ApgInstExpVar g = new ApgInstExpVar("i");
+      assertEquals(g, new ApgTransExpId(g).G);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpId(new ApgInstExpVar("i")), new ApgTransExpId(new ApgInstExpVar("i")));
+    }
+
+    @Test
+    void toStringContainsIdentity() {
+      assertTrue(new ApgTransExpId(new ApgInstExpVar("i")).toString().contains("identity"));
+    }
+
+    @Test
+    void typeReturnsSameDomainAndCodomain() {
+      AqlTyping typing = setupTypingWithInstances("i");
+      Pair<ApgInstExp, ApgInstExp> result = new ApgTransExpId(new ApgInstExpVar("i")).type(typing);
+      assertEquals(result.first, result.second);
+    }
+  }
+
+  @Nested
+  class ApgTransExpTerminalTest {
+
+    @Test
+    void constructorSetsField() {
+      ApgInstExpVar g = new ApgInstExpVar("i");
+      assertEquals(g, new ApgTransExpTerminal(g).G);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpTerminal(new ApgInstExpVar("i")),
+          new ApgTransExpTerminal(new ApgInstExpVar("i")));
+    }
+
+    @Test
+    void toStringContainsUnit() {
+      assertTrue(new ApgTransExpTerminal(new ApgInstExpVar("i")).toString().contains("unit"));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() {
+      ApgTransExpTerminal term = new ApgTransExpTerminal(new ApgInstExpVar("i"));
+      @SuppressWarnings("unchecked")
+      ApgTransExp.ApgTransExpVisitor<String, Void> visitor =
+          mock(ApgTransExp.ApgTransExpVisitor.class);
+      term.accept(null, visitor);
+      verify(visitor).visit(null, term);
+    }
+  }
+
+  @Nested
+  class ApgTransExpInitialTest {
+
+    @Test
+    void constructorSetsField() {
+      ApgInstExpVar g = new ApgInstExpVar("i");
+      assertEquals(g, new ApgTransExpInitial(g).G);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpInitial(new ApgInstExpVar("i")),
+          new ApgTransExpInitial(new ApgInstExpVar("i")));
+    }
+
+    @Test
+    void toStringContainsEmpty() {
+      assertTrue(new ApgTransExpInitial(new ApgInstExpVar("i")).toString().contains("empty"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpFstTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgInstExpVar g1 = new ApgInstExpVar("i1");
+      ApgInstExpVar g2 = new ApgInstExpVar("i2");
+      ApgTransExpFst fst = new ApgTransExpFst(g1, g2);
+      assertEquals(g1, fst.G1);
+      assertEquals(g2, fst.G2);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpFst(new ApgInstExpVar("a"), new ApgInstExpVar("b")),
+          new ApgTransExpFst(new ApgInstExpVar("a"), new ApgInstExpVar("b")));
+    }
+
+    @Test
+    void toStringContainsFst() {
+      assertTrue(
+          new ApgTransExpFst(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("fst"));
+    }
+
+    @Test
+    void typeReturnsTimes() {
+      AqlTyping typing = setupTypingWithInstances("a", "b");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpFst(new ApgInstExpVar("a"), new ApgInstExpVar("b")).type(typing);
+      assertTrue(result.first instanceof ApgInstExpTimes);
+      assertEquals(new ApgInstExpVar("a"), result.second);
+    }
+
+    @Test
+    void typeThrowsOnDifferentTypesides() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("ts1", Unit.unit);
+      typing.defs.apgts.put("ts2", Unit.unit);
+      typing.defs.apgschemas.put("s1", new ApgTyExpVar("ts1"));
+      typing.defs.apgschemas.put("s2", new ApgTyExpVar("ts2"));
+      typing.defs.apgis.put("a", new ApgSchExpVar("s1"));
+      typing.defs.apgis.put("b", new ApgSchExpVar("s2"));
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransExpFst(new ApgInstExpVar("a"), new ApgInstExpVar("b")).type(typing));
+    }
+  }
+
+  @Nested
+  class ApgTransExpSndTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgInstExpVar g1 = new ApgInstExpVar("i1");
+      ApgInstExpVar g2 = new ApgInstExpVar("i2");
+      ApgTransExpSnd snd = new ApgTransExpSnd(g1, g2);
+      assertEquals(g1, snd.G1);
+      assertEquals(g2, snd.G2);
+    }
+
+    @Test
+    void typeReturnsSndProjection() {
+      AqlTyping typing = setupTypingWithInstances("a", "b");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpSnd(new ApgInstExpVar("a"), new ApgInstExpVar("b")).type(typing);
+      assertTrue(result.first instanceof ApgInstExpTimes);
+      assertEquals(new ApgInstExpVar("b"), result.second);
+    }
+
+    @Test
+    void toStringContainsSnd() {
+      assertTrue(
+          new ApgTransExpSnd(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("snd"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpPairTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpPair pair = new ApgTransExpPair(h1, h2);
+      assertEquals(h1, pair.h1);
+      assertEquals(h2, pair.h2);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpPair(new ApgTransExpVar("a"), new ApgTransExpVar("b")),
+          new ApgTransExpPair(new ApgTransExpVar("a"), new ApgTransExpVar("b")));
+    }
+
+    @Test
+    void typeThrowsOnDomainMismatch() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i3", "i4");
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransExpPair(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+                  .type(typing));
+    }
+
+    @Test
+    void typeReturnsPairWithTimes() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i1", "i3");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpPair(new ApgTransExpVar("t1"), new ApgTransExpVar("t2")).type(typing);
+      assertEquals(new ApgInstExpVar("i1"), result.first);
+      assertTrue(result.second instanceof ApgInstExpTimes);
+    }
+  }
+
+  @Nested
+  class ApgTransExpInlTest {
+
+    @Test
+    void typeReturnsInlInjection() {
+      AqlTyping typing = setupTypingWithInstances("a", "b");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpInl(new ApgInstExpVar("a"), new ApgInstExpVar("b")).type(typing);
+      assertEquals(new ApgInstExpVar("a"), result.first);
+      assertTrue(result.second instanceof ApgInstExpPlus);
+    }
+
+    @Test
+    void toStringContainsInl() {
+      assertTrue(
+          new ApgTransExpInl(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("inl"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpInrTest {
+
+    @Test
+    void typeReturnsInrInjection() {
+      AqlTyping typing = setupTypingWithInstances("a", "b");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpInr(new ApgInstExpVar("a"), new ApgInstExpVar("b")).type(typing);
+      assertEquals(new ApgInstExpVar("b"), result.first);
+      assertTrue(result.second instanceof ApgInstExpPlus);
+    }
+
+    @Test
+    void toStringContainsInr() {
+      assertTrue(
+          new ApgTransExpInr(new ApgInstExpVar("a"), new ApgInstExpVar("b"))
+              .toString()
+              .contains("inr"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpCaseTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpCase caseExp = new ApgTransExpCase(h1, h2);
+      assertEquals(h1, caseExp.h1);
+      assertEquals(h2, caseExp.h2);
+    }
+
+    @Test
+    void typeThrowsOnCodomainMismatch() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i3", "i4");
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransExpCase(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+                  .type(typing));
+    }
+
+    @Test
+    void typeReturnsCaseWithPlus() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i3", "t2", "i2", "i3");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpCase(new ApgTransExpVar("t1"), new ApgTransExpVar("t2")).type(typing);
+      assertTrue(result.first instanceof ApgInstExpPlus);
+      assertEquals(new ApgInstExpVar("i3"), result.second);
+    }
+
+    @Test
+    void toStringContainsPipe() {
+      assertTrue(
+          new ApgTransExpCase(new ApgTransExpVar("a"), new ApgTransExpVar("b"))
+              .toString()
+              .contains("|"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpComposeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpCompose compose = new ApgTransExpCompose(h1, h2);
+      assertEquals(h1, compose.h1);
+      assertEquals(h2, compose.h2);
+    }
+
+    @Test
+    void typeThrowsOnIntermediateMismatch() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i3", "i4");
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransExpCompose(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+                  .type(typing));
+    }
+
+    @Test
+    void typeSucceedsOnMatchingIntermediate() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i2", "i3");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpCompose(new ApgTransExpVar("t1"), new ApgTransExpVar("t2")).type(typing);
+      assertEquals(new ApgInstExpVar("i1"), result.first);
+      assertEquals(new ApgInstExpVar("i3"), result.second);
+    }
+
+    @Test
+    void toStringContainsSemicolon() {
+      assertTrue(
+          new ApgTransExpCompose(new ApgTransExpVar("a"), new ApgTransExpVar("b"))
+              .toString()
+              .contains(";"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpEqualizeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpEqualize eq = new ApgTransExpEqualize(h1, h2);
+      assertEquals(h1, eq.h1);
+      assertEquals(h2, eq.h2);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpEqualize(new ApgTransExpVar("a"), new ApgTransExpVar("b")),
+          new ApgTransExpEqualize(new ApgTransExpVar("a"), new ApgTransExpVar("b")));
+    }
+
+    @Test
+    void typeThrowsOnDomainMismatch() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i3", "t2", "i2", "i3");
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              new ApgTransExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+                  .type(typing));
+    }
+
+    @Test
+    void typeReturnsEqualizeResult() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i1", "i2");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2")).type(typing);
+      assertTrue(result.first instanceof ApgInstExpEqualize);
+      assertEquals(new ApgInstExpVar("i1"), result.second);
+    }
+
+    @Test
+    void toStringContainsEqualize() {
+      assertTrue(
+          new ApgTransExpEqualize(new ApgTransExpVar("a"), new ApgTransExpVar("b"))
+              .toString()
+              .contains("equalize"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpEqualizeUTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpVar h = new ApgTransExpVar("t3");
+      ApgTransExpEqualizeU equ = new ApgTransExpEqualizeU(h1, h2, h);
+      assertEquals(h1, equ.h1);
+      assertEquals(h2, equ.h2);
+      assertEquals(h, equ.h);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpEqualizeU(
+              new ApgTransExpVar("a"), new ApgTransExpVar("b"), new ApgTransExpVar("c")),
+          new ApgTransExpEqualizeU(
+              new ApgTransExpVar("a"), new ApgTransExpVar("b"), new ApgTransExpVar("c")));
+    }
+
+    @Test
+    void toStringContainsEqualizeU() {
+      assertTrue(
+          new ApgTransExpEqualizeU(
+                  new ApgTransExpVar("a"), new ApgTransExpVar("b"), new ApgTransExpVar("c"))
+              .toString()
+              .contains("equalize_u"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpCoEqualizeTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpCoEqualize ceq = new ApgTransExpCoEqualize(h1, h2);
+      assertEquals(h1, ceq.h1);
+      assertEquals(h2, ceq.h2);
+    }
+
+    @Test
+    void typeReturnsCoEqualizeResult() {
+      AqlTyping typing = setupTypingWithTransforms("t1", "i1", "i2", "t2", "i1", "i2");
+      Pair<ApgInstExp, ApgInstExp> result =
+          new ApgTransExpCoEqualize(new ApgTransExpVar("t1"), new ApgTransExpVar("t2"))
+              .type(typing);
+      assertEquals(new ApgInstExpVar("i2"), result.first);
+      assertTrue(result.second instanceof ApgInstExpCoEqualize);
+    }
+
+    @Test
+    void toStringContainsCoequalize() {
+      assertTrue(
+          new ApgTransExpCoEqualize(new ApgTransExpVar("a"), new ApgTransExpVar("b"))
+              .toString()
+              .contains("coequalize"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpCoEqualizeUTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgTransExpVar h1 = new ApgTransExpVar("t1");
+      ApgTransExpVar h2 = new ApgTransExpVar("t2");
+      ApgTransExpVar h = new ApgTransExpVar("t3");
+      ApgTransExpCoEqualizeU cequ = new ApgTransExpCoEqualizeU(h1, h2, h);
+      assertEquals(h1, cequ.h1);
+      assertEquals(h2, cequ.h2);
+      assertEquals(h, cequ.h);
+    }
+
+    @Test
+    void toStringContainsCoequalizeU() {
+      assertTrue(
+          new ApgTransExpCoEqualizeU(
+                  new ApgTransExpVar("a"), new ApgTransExpVar("b"), new ApgTransExpVar("c"))
+              .toString()
+              .contains("coequalize_u"));
+    }
+  }
+
+  @Nested
+  class ApgTransExpDeltaTest {
+
+    @Test
+    void constructorSetsFields() {
+      ApgMapExpVar f = new ApgMapExpVar("m");
+      ApgTransExpVar h = new ApgTransExpVar("t");
+      ApgTransExpDelta delta = new ApgTransExpDelta(f, h);
+      assertEquals(f, delta.F);
+      assertEquals(h, delta.h);
+    }
+
+    @Test
+    void equalsSame() {
+      assertEquals(
+          new ApgTransExpDelta(new ApgMapExpVar("m"), new ApgTransExpVar("t")),
+          new ApgTransExpDelta(new ApgMapExpVar("m"), new ApgTransExpVar("t")));
+    }
+
+    @Test
+    void toStringContainsDelta() {
+      assertTrue(
+          new ApgTransExpDelta(new ApgMapExpVar("m"), new ApgTransExpVar("t"))
+              .toString()
+              .contains("delta"));
+    }
+
+    @Test
+    void depsUnionsBoth() {
+      ApgTransExpDelta delta =
+          new ApgTransExpDelta(new ApgMapExpVar("m"), new ApgTransExpVar("t"));
+      assertEquals(2, delta.deps().size());
+    }
+  }
+
+  @Test
+  void optionsReturnsEmptyMap() {
+    assertTrue(new ApgTransExpVar("x").options().isEmpty());
+  }
+}

--- a/src/catdata/apg/exp/ApgTyExpTest.java
+++ b/src/catdata/apg/exp/ApgTyExpTest.java
@@ -1,0 +1,275 @@
+package catdata.apg.exp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import catdata.LocStr;
+import catdata.Pair;
+import catdata.Unit;
+import catdata.apg.exp.ApgTyExp.ApgTyExpRaw;
+import catdata.apg.exp.ApgTyExp.ApgTyExpVar;
+import catdata.cql.Kind;
+import catdata.cql.exp.AqlTyping;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApgTyExpTest {
+
+  @Nested
+  class ApgTyExpVarTest {
+
+    @Test
+    void constructorSetsVar() {
+      ApgTyExpVar v = new ApgTyExpVar("myVar");
+      assertEquals("myVar", v.var);
+    }
+
+    @Test
+    void kindReturnsApgTypeside() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertEquals(Kind.APG_typeside, v.kind());
+    }
+
+    @Test
+    void isVarReturnsTrue() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertTrue(v.isVar());
+    }
+
+    @Test
+    void toStringReturnsVar() {
+      ApgTyExpVar v = new ApgTyExpVar("myTypeside");
+      assertEquals("myTypeside", v.toString());
+    }
+
+    @Test
+    void depsReturnsSingletonWithCorrectKind() {
+      ApgTyExpVar v = new ApgTyExpVar("ts1");
+      Collection<Pair<String, Kind>> deps = v.deps();
+      assertEquals(1, deps.size());
+      Pair<String, Kind> dep = deps.iterator().next();
+      assertEquals("ts1", dep.first);
+      assertEquals(Kind.APG_typeside, dep.second);
+    }
+
+    @Test
+    void equalsSameVar() {
+      ApgTyExpVar v1 = new ApgTyExpVar("x");
+      ApgTyExpVar v2 = new ApgTyExpVar("x");
+      assertEquals(v1, v2);
+      assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentVar() {
+      ApgTyExpVar v1 = new ApgTyExpVar("x");
+      ApgTyExpVar v2 = new ApgTyExpVar("y");
+      assertNotEquals(v1, v2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertEquals(v, v);
+    }
+
+    @Test
+    void notEqualsNull() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertNotEquals(null, v);
+    }
+
+    @Test
+    void notEqualsDifferentType() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertNotEquals("x", v);
+    }
+
+    @Test
+    void typeReturnsUnitWhenDefined() {
+      AqlTyping typing = new AqlTyping();
+      typing.defs.apgts.put("x", Unit.unit);
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertEquals(Unit.unit, v.type(typing));
+    }
+
+    @Test
+    void typeThrowsWhenUndefined() {
+      AqlTyping typing = new AqlTyping();
+      ApgTyExpVar v = new ApgTyExpVar("missing");
+      assertThrows(RuntimeException.class, () -> v.type(typing));
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() throws Exception {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      @SuppressWarnings("unchecked")
+      ApgTyExp.ApgTyExpVisitor<String, Void, RuntimeException> visitor =
+          mock(ApgTyExp.ApgTyExpVisitor.class);
+      v.accept(null, visitor);
+      verify(visitor).visit(null, v);
+    }
+
+    @Test
+    void coAcceptDelegatesToCoVisitor() throws Exception {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      @SuppressWarnings("unchecked")
+      ApgTyExp.ApgTyExpCoVisitor<String, Void, RuntimeException> coVisitor =
+          mock(ApgTyExp.ApgTyExpCoVisitor.class);
+      v.coaccept(null, coVisitor, "result");
+      verify(coVisitor).visitApgTyExpVar(null, "result");
+    }
+
+    @Test
+    void varMethodCreatesNewVar() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      var newVar = v.Var("y");
+      assertNotNull(newVar);
+      assertTrue(newVar instanceof ApgTyExpVar);
+      assertEquals("y", ((ApgTyExpVar) newVar).var);
+    }
+
+    @Test
+    void optionsReturnsEmptyMap() {
+      ApgTyExpVar v = new ApgTyExpVar("x");
+      assertTrue(v.options().isEmpty());
+    }
+  }
+
+  @Nested
+  class ApgTyExpRawTest {
+
+    private ApgTyExpRaw createEmptyRaw() {
+      return new ApgTyExpRaw(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
+
+    private ApgTyExpRaw createRawWithType(String name, String className, String parseFn) {
+      List<Pair<LocStr, Pair<String, String>>> types =
+          List.of(new Pair<>(new LocStr(0, name), new Pair<>(className, parseFn)));
+      return new ApgTyExpRaw(Collections.emptyList(), types, Collections.emptyList());
+    }
+
+    @Test
+    void constructorSetsFields() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertNotNull(raw.imports);
+      assertNotNull(raw.types);
+      assertNotNull(raw.udfs);
+      assertTrue(raw.imports.isEmpty());
+      assertTrue(raw.types.isEmpty());
+      assertTrue(raw.udfs.isEmpty());
+    }
+
+    @Test
+    void constructorWithTypes() {
+      ApgTyExpRaw raw = createRawWithType("Int", "java.lang.Integer", "parseInt");
+      assertEquals(1, raw.types.size());
+      assertTrue(raw.types.containsKey("Int"));
+      assertEquals("java.lang.Integer", raw.types.get("Int").first);
+    }
+
+    @Test
+    void kindReturnsApgTypeside() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertEquals(Kind.APG_typeside, raw.kind());
+    }
+
+    @Test
+    void depsEmptyWhenNoImports() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertTrue(raw.deps().isEmpty());
+    }
+
+    @Test
+    void depsIncludesImportDeps() {
+      ApgTyExpVar importVar = new ApgTyExpVar("imported");
+      ApgTyExpRaw raw =
+          new ApgTyExpRaw(List.of(importVar), Collections.emptyList(), Collections.emptyList());
+      Collection<Pair<String, Kind>> deps = raw.deps();
+      assertEquals(1, deps.size());
+      assertEquals("imported", deps.iterator().next().first);
+    }
+
+    @Test
+    void equalsSameContent() {
+      ApgTyExpRaw r1 = createEmptyRaw();
+      ApgTyExpRaw r2 = createEmptyRaw();
+      assertEquals(r1, r2);
+      assertEquals(r1.hashCode(), r2.hashCode());
+    }
+
+    @Test
+    void notEqualsDifferentTypes() {
+      ApgTyExpRaw r1 = createEmptyRaw();
+      ApgTyExpRaw r2 = createRawWithType("Int", "java.lang.Integer", "parseInt");
+      assertNotEquals(r1, r2);
+    }
+
+    @Test
+    void equalsReflexive() {
+      ApgTyExpRaw r = createEmptyRaw();
+      assertEquals(r, r);
+    }
+
+    @Test
+    void notEqualsNull() {
+      ApgTyExpRaw r = createEmptyRaw();
+      assertNotEquals(null, r);
+    }
+
+    @Test
+    void toStringContainsLiteral() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertTrue(raw.toString().contains("literal"));
+    }
+
+    @Test
+    void rawReturnsNonNullMap() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertNotNull(raw.raw());
+    }
+
+    @Test
+    void acceptDelegatesToVisitor() throws Exception {
+      ApgTyExpRaw raw = createEmptyRaw();
+      @SuppressWarnings("unchecked")
+      ApgTyExp.ApgTyExpVisitor<String, Void, RuntimeException> visitor =
+          mock(ApgTyExp.ApgTyExpVisitor.class);
+      raw.accept(null, visitor);
+      verify(visitor).visit(null, raw);
+    }
+
+    @Test
+    void coAcceptDelegatesToCoVisitor() throws Exception {
+      ApgTyExpRaw raw = createEmptyRaw();
+      @SuppressWarnings("unchecked")
+      ApgTyExp.ApgTyExpCoVisitor<String, Void, RuntimeException> coVisitor =
+          mock(ApgTyExp.ApgTyExpCoVisitor.class);
+      raw.coaccept(null, coVisitor, "result");
+      verify(coVisitor).visitApgTyExpRaw(null, "result");
+    }
+
+    @Test
+    void isVarReturnsFalse() {
+      ApgTyExpRaw raw = createEmptyRaw();
+      assertFalse(raw.isVar());
+    }
+  }
+
+  @Test
+  void baseTypeReturnsUnit() {
+    ApgTyExpVar v = new ApgTyExpVar("x");
+    AqlTyping typing = new AqlTyping();
+    typing.defs.apgts.put("x", Unit.unit);
+    assertEquals(Unit.unit, v.type(typing));
+  }
+}

--- a/src/catdata/cql/CqlExamplesTest.java
+++ b/src/catdata/cql/CqlExamplesTest.java
@@ -1,0 +1,62 @@
+package catdata.cql;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import catdata.Program;
+import catdata.cql.exp.AqlParserFactory;
+import catdata.cql.exp.Exp;
+import catdata.ide.Example;
+import catdata.ide.Examples;
+import catdata.ide.Language;
+
+/**
+ * JUnit 5 wrapper around the existing CQL self-test.
+ * Runs all built-in CQL examples and verifies they execute without exceptions.
+ */
+class CqlExamplesTest {
+
+    /** Names to skip (require external resources or are too slow). */
+    private static final Set<String> SKIP = Set.of(
+        "TutorialTSP", "QuickSQL", "Stdlib", "Imports"
+    );
+
+    @Test
+    @Tag("integration")
+    void allBuiltInExamplesShouldPass() {
+        Map<String, Throwable> failures = AqlTester.deleteFilesCreatedDuring(() -> {
+            return AqlTester.doSelfTestSilent();
+        });
+
+        if (!failures.isEmpty()) {
+            StringBuilder sb = new StringBuilder("CQL example failures:\n");
+            for (Map.Entry<String, Throwable> entry : failures.entrySet()) {
+                sb.append("  - ").append(entry.getKey())
+                  .append(": ").append(entry.getValue().getMessage())
+                  .append("\n");
+            }
+            fail(sb.toString());
+        }
+    }
+
+    @Test
+    void parserShouldLoadAllExamples() {
+        for (Example e : Examples.getExamples(Language.CQL)) {
+            if (SKIP.contains(e.getName())) continue;
+
+            try {
+                Program<Exp<?>> prog = AqlParserFactory.getParser().parseProgram(e.getText());
+                assertTrue(prog.exps.size() > 0,
+                    "Example '" + e.getName() + "' should have at least one expression");
+            } catch (Exception ex) {
+                fail("Failed to parse example '" + e.getName() + "': " + ex.getMessage());
+            }
+        }
+    }
+}

--- a/src/catdata/cql/fdm/AnonymizedTest.java
+++ b/src/catdata/cql/fdm/AnonymizedTest.java
@@ -1,0 +1,75 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AnonymizedTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertSame(inst.schema(), anon.schema());
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void gensDelegates() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertNotNull(anon.gens());
+    }
+
+    @Test
+    void sksDelegates() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertNotNull(anon.sks());
+    }
+
+    @Test
+    void algebraIsNotNull() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertNotNull(anon.algebra());
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertNotNull(anon.dp());
+    }
+
+    @Test
+    void requireConsistencyDelegates() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertEquals(inst.requireConsistency(), anon.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaDelegates() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertEquals(inst.allowUnsafeJava(), anon.allowUnsafeJava());
+    }
+
+    @Test
+    void algebraPreservesEntitySize() {
+      var inst = FdmTestHelpers.instanceWithAtt();
+      var anon = new Anonymized<>(inst);
+      assertEquals(inst.algebra().size("E"), anon.algebra().size("E"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ChaseTest.java
+++ b/src/catdata/cql/fdm/ChaseTest.java
@@ -1,0 +1,149 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ChaseTest {
+
+  @Nested
+  class BSTTests {
+
+    @Test
+    void constructorSetsNode() {
+      Chase.BST bst = new Chase.BST(42);
+      assertEquals(42, bst.node);
+    }
+
+    @Test
+    void addReturnsFalseForSameNode() {
+      Chase.BST bst = new Chase.BST(5);
+      assertFalse(bst.add(5));
+    }
+
+    @Test
+    void addReturnsTrueForNewNode() {
+      Chase.BST bst = new Chase.BST(5);
+      assertTrue(bst.add(10));
+    }
+
+    @Test
+    void addReturnsFalseForDuplicate() {
+      Chase.BST bst = new Chase.BST(5);
+      assertTrue(bst.add(10));
+      assertFalse(bst.add(10));
+    }
+
+    @Test
+    void foreachVisitsAllNodes() {
+      Chase.BST bst = new Chase.BST(1);
+      bst.add(2);
+      bst.add(3);
+      List<Integer> visited = new ArrayList<>();
+      bst.foreach(visited::add);
+      assertTrue(visited.contains(1));
+      assertTrue(visited.contains(2));
+      assertTrue(visited.contains(3));
+      assertEquals(3, visited.size());
+    }
+
+    @Test
+    void foreachNoRootSkipsRoot() {
+      Chase.BST bst = new Chase.BST(1);
+      bst.add(2);
+      bst.add(3);
+      List<Integer> visited = new ArrayList<>();
+      bst.foreachNoRoot(visited::add);
+      assertFalse(visited.contains(1));
+      assertTrue(visited.contains(2));
+      assertTrue(visited.contains(3));
+    }
+
+    @Test
+    void foreachNoRootEmptySetDoesNothing() {
+      Chase.BST bst = new Chase.BST(1);
+      List<Integer> visited = new ArrayList<>();
+      bst.foreachNoRoot(visited::add);
+      assertTrue(visited.isEmpty());
+    }
+
+    @Test
+    void foreachOnlyRootVisitsRoot() {
+      Chase.BST bst = new Chase.BST(7);
+      List<Integer> visited = new ArrayList<>();
+      bst.foreach(visited::add);
+      assertEquals(List.of(7), visited);
+    }
+
+    @Test
+    void equalBstsAreEqual() {
+      Chase.BST a = new Chase.BST(1);
+      a.add(2);
+      Chase.BST b = new Chase.BST(1);
+      b.add(2);
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void differentNodeNotEqual() {
+      Chase.BST a = new Chase.BST(1);
+      Chase.BST b = new Chase.BST(2);
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    void differentSetNotEqual() {
+      Chase.BST a = new Chase.BST(1);
+      a.add(2);
+      Chase.BST b = new Chase.BST(1);
+      b.add(3);
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    void nullSetVsNonNullNotEqual() {
+      Chase.BST a = new Chase.BST(1);
+      Chase.BST b = new Chase.BST(1);
+      b.add(2);
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    void equalToSelf() {
+      Chase.BST bst = new Chase.BST(1);
+      assertEquals(bst, bst);
+    }
+
+    @Test
+    void notEqualToNull() {
+      assertNotEquals(null, new Chase.BST(1));
+    }
+
+    @Test
+    void notEqualToDifferentType() {
+      assertFalse(new Chase.BST(1).equals("not a BST"));
+    }
+
+    @Test
+    void toStringWithoutSet() {
+      assertEquals("{1}", new Chase.BST(1).toString());
+    }
+
+    @Test
+    void toStringWithSet() {
+      Chase.BST bst = new Chase.BST(1);
+      bst.add(2);
+      String str = bst.toString();
+      assertTrue(str.startsWith("{1,"));
+      assertTrue(str.contains("2"));
+      assertTrue(str.endsWith("}"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CoEvalEvalCoUnitTransformTest.java
+++ b/src/catdata/cql/fdm/CoEvalEvalCoUnitTransformTest.java
@@ -1,0 +1,57 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class CoEvalEvalCoUnitTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesTransform() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalCoUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.src());
+      assertNotNull(t.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalCoUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalCoUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.sks());
+    }
+
+    @Test
+    void dstIsOriginalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalCoUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.dst());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CoEvalEvalUnitTransformTest.java
+++ b/src/catdata/cql/fdm/CoEvalEvalUnitTransformTest.java
@@ -1,0 +1,67 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class CoEvalEvalUnitTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesTransform() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.src());
+      assertNotNull(t.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void srcIsOriginalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.src());
+    }
+
+    @Test
+    void dstIsEvalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertTrue(t.dst() instanceof EvalInstance);
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new CoEvalEvalUnitTransform<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(t.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CoEvalInstanceTest.java
+++ b/src/catdata/cql/fdm/CoEvalInstanceTest.java
@@ -1,0 +1,66 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class CoEvalInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var coeval = new CoEvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertEquals(schema.ens, coeval.schema().ens);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void algebraIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var coeval = new CoEvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(coeval.algebra());
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var coeval = new CoEvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(coeval.dp());
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var coeval = new CoEvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(coeval.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var coeval = new CoEvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(coeval.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CoEvalTransformTest.java
+++ b/src/catdata/cql/fdm/CoEvalTransformTest.java
@@ -1,0 +1,64 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class CoEvalTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSrcAndDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var coeval = new CoEvalTransform<>(query, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(coeval.src());
+      assertNotNull(coeval.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void srcIsCoEvalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var coeval = new CoEvalTransform<>(query, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertTrue(coeval.src() instanceof CoEvalInstance);
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var coeval = new CoEvalTransform<>(query, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(coeval.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var coeval = new CoEvalTransform<>(query, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(coeval.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ColimitInstanceTest.java
+++ b/src/catdata/cql/fdm/ColimitInstanceTest.java
@@ -1,0 +1,97 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Instance;
+import catdata.cql.Transform;
+import catdata.graph.DMG;
+
+class ColimitInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void emptyColimitCreatesInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      DMG<String, String> shape = new DMG<>(Collections.emptySet(), Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = Collections.emptyMap();
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertNotNull(colimit);
+    }
+
+    @Test
+    void singleNodeColimit() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      DMG<String, String> shape = new DMG<>(Collections.singleton("n1"), Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = new HashMap<>();
+      nodes.put("n1", FdmTestHelpers.singleElementInstance());
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertNotNull(colimit.algebra());
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void schemaMatchesInput() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      DMG<String, String> shape = new DMG<>(Collections.singleton("n1"), Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = new HashMap<>();
+      nodes.put("n1", FdmTestHelpers.singleElementInstance());
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertEquals(schema.ens, colimit.schema().ens);
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      DMG<String, String> shape = new DMG<>(Collections.singleton("n1"), Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = new HashMap<>();
+      nodes.put("n1", FdmTestHelpers.singleElementInstance());
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertNotNull(colimit.dp());
+    }
+
+    @Test
+    void getReturnsInclusionTransform() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      DMG<String, String> shape = new DMG<>(Collections.singleton("n1"), Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = new HashMap<>();
+      nodes.put("n1", FdmTestHelpers.singleElementInstance());
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertNotNull(colimit.get("n1"));
+    }
+
+    @Test
+    void twoNodeColimit() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var nodesSet = new HashSet<String>();
+      nodesSet.add("n1");
+      nodesSet.add("n2");
+      DMG<String, String> shape = new DMG<>(nodesSet, Collections.emptyMap());
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> nodes = new HashMap<>();
+      nodes.put("n1", FdmTestHelpers.singleElementInstance());
+      nodes.put("n2", FdmTestHelpers.singleElementInstance());
+      Map<String, Transform<String, String, String, String, String, String, String, String, String, String, String, String, String>> edges = Collections.emptyMap();
+      var colimit = new ColimitInstance<>(schema, shape, nodes, edges, AqlOptions.initialOptions);
+      assertEquals(2, colimit.algebra().size("E"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ComposeTransformTest.java
+++ b/src/catdata/cql/fdm/ComposeTransformTest.java
@@ -1,0 +1,50 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ComposeTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void compositionSetsSrcAndDst() {
+      var inst1 = FdmTestHelpers.singleElementInstance();
+      var inst2 = FdmTestHelpers.singleElementInstance();
+      var inst3 = FdmTestHelpers.singleElementInstance();
+      var t1 = new IdentityTransform<>(inst1, Optional.of(inst2));
+      var t2 = new IdentityTransform<>(inst2, Optional.of(inst3));
+      var composed = new ComposeTransform<>(t1, t2);
+      assertSame(inst1, composed.src());
+      assertSame(inst3, composed.dst());
+    }
+  }
+
+  @Nested
+  class GensAndSks {
+
+    @Test
+    void gensComposesTransforms() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t1 = new IdentityTransform<>(inst, Optional.empty());
+      var t2 = new IdentityTransform<>(inst, Optional.empty());
+      var composed = new ComposeTransform<>(t1, t2);
+      var result = composed.gens().apply("e1", "E");
+      assertNotNull(result);
+    }
+
+    @Test
+    void sksComposesTransforms() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t1 = new IdentityTransform<>(inst, Optional.empty());
+      var t2 = new IdentityTransform<>(inst, Optional.empty());
+      var composed = new ComposeTransform<>(t1, t2);
+      assertNotNull(composed.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CoprodInstanceTest.java
+++ b/src/catdata/cql/fdm/CoprodInstanceTest.java
@@ -1,0 +1,75 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.Instance;
+
+class CoprodInstanceTest {
+
+  private CoprodInstance<String, String, String, String, String, String, String, String, String> createCoprod(
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> insts) {
+    var schema = FdmTestHelpers.singleEntitySchema();
+    return new CoprodInstance<>(insts, schema, false, false);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void emptyMapProducesEmptyInstance() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertEquals(0, coprod.algebra().size("E"));
+    }
+
+    @Test
+    void singleInstanceCoprod() {
+      Map<String, Instance<String, String, String, String, String, String, String, String, String>> insts = new HashMap<>();
+      insts.put("i1", FdmTestHelpers.singleElementInstance());
+      var coprod = createCoprod(insts);
+      assertEquals(1, coprod.algebra().size("E"));
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void schemaIsProvided() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertEquals(FdmTestHelpers.singleEntitySchema().ens, coprod.schema().ens);
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertNotNull(coprod.dp());
+    }
+
+    @Test
+    void algebraIsNotNull() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertNotNull(coprod.algebra());
+    }
+
+    @Test
+    void requireConsistencyMatchesInput() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertFalse(coprod.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaMatchesInput() {
+      var coprod = createCoprod(Collections.emptyMap());
+      assertFalse(coprod.allowUnsafeJava());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/CqlPivotTest.java
+++ b/src/catdata/cql/fdm/CqlPivotTest.java
@@ -1,0 +1,79 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class CqlPivotTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsInputInstance() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertSame(inst, pivot.I);
+    }
+
+    @Test
+    void constructorCreatesIntermediateSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertNotNull(pivot.intI);
+    }
+
+    @Test
+    void constructorCreatesMapping() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertNotNull(pivot.F);
+    }
+
+    @Test
+    void constructorCreatesTargetInstance() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertNotNull(pivot.J);
+    }
+  }
+
+  @Nested
+  class PivotBehavior {
+
+    @Test
+    void pivotSchemaHasOneEntityPerElement() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      // single entity "E" with one element "e1" -> intermediate schema has entity "e1"
+      assertTrue(pivot.intI.ens.contains("e1"));
+    }
+
+    @Test
+    void pivotInstanceHasData() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      // J should have data corresponding to the pivot
+      assertNotNull(pivot.J.algebra());
+    }
+
+    @Test
+    void pivotMappingSourceIsIntermediateSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertSame(pivot.intI, pivot.F.src);
+    }
+
+    @Test
+    void pivotMappingTargetIsOriginalSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var pivot = new CqlPivot<>(inst, AqlOptions.initialOptions);
+      assertSame(inst.schema(), pivot.F.dst);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DeltaAlgebraTest.java
+++ b/src/catdata/cql/fdm/DeltaAlgebraTest.java
@@ -1,0 +1,132 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.Pair;
+import catdata.cql.Term;
+
+class DeltaAlgebraTest {
+
+  private DeltaAlgebra<String, String, String, String, String, String, String, String, String, String, String, String>
+      createDeltaAlgebra() {
+    var schema = FdmTestHelpers.singleEntitySchema();
+    var mapping = FdmTestHelpers.identityMapping(schema);
+    var inst = FdmTestHelpers.singleElementInstance();
+    return new DeltaAlgebra<>(mapping, inst);
+  }
+
+  @Nested
+  class SchemaMethod {
+
+    @Test
+    void schemaReturnsMappingSource() {
+      var alg = createDeltaAlgebra();
+      assertEquals(FdmTestHelpers.singleEntitySchema().ens, alg.schema().ens);
+    }
+  }
+
+  @Nested
+  class EnMethod {
+
+    @Test
+    void enReturnsPairedElements() {
+      var alg = createDeltaAlgebra();
+      var elements = alg.en("E");
+      assertEquals(1, elements.size());
+      Pair<String, String> elem = elements.iterator().next();
+      assertEquals("E", elem.first);
+      assertEquals("e1", elem.second);
+    }
+
+    @Test
+    void enCachesResult() {
+      var alg = createDeltaAlgebra();
+      var first = alg.en("E");
+      var second = alg.en("E");
+      assertSame(first, second);
+    }
+  }
+
+  @Nested
+  class GenMethod {
+
+    @Test
+    void genReturnsItself() {
+      var alg = createDeltaAlgebra();
+      var gen = new Pair<>("E", "e1");
+      assertSame(gen, alg.gen(gen));
+    }
+  }
+
+  @Nested
+  class ReprMethod {
+
+    @Test
+    void reprReturnsTermGen() {
+      var alg = createDeltaAlgebra();
+      var gen = new Pair<>("E", "e1");
+      assertEquals(Term.Gen(gen), alg.repr("E", gen));
+    }
+  }
+
+  @Nested
+  class SizeMethod {
+
+    @Test
+    void sizeReturnsCount() {
+      var alg = createDeltaAlgebra();
+      assertEquals(1, alg.size("E"));
+    }
+  }
+
+  @Nested
+  class SkMethod {
+
+    @Test
+    void skReturnsTermSk() {
+      var alg = createDeltaAlgebra();
+      assertEquals(Term.Sk("y1"), alg.sk("y1"));
+    }
+  }
+
+  @Nested
+  class PrintMethods {
+
+    @Test
+    void toStringProverDelegates() {
+      var alg = createDeltaAlgebra();
+      assertNotNull(alg.toStringProver());
+    }
+
+    @Test
+    void printXShowsEntityAndValue() {
+      var alg = createDeltaAlgebra();
+      var result = alg.printX("E", new Pair<>("E", "e1"));
+      assertNotNull(result);
+      assertTrue(result.toString().contains("e1"));
+    }
+  }
+
+  @Nested
+  class TypeAlgebra {
+
+    @Test
+    void hasFreeTypeAlgebraDelegates() {
+      var alg = createDeltaAlgebra();
+      assertTrue(alg.hasFreeTypeAlgebra());
+    }
+
+    @Test
+    void hasNullsDelegates() {
+      var alg = createDeltaAlgebra();
+      // ImportAlgebra hasNulls returns true when sks are empty
+      assertNotNull(alg.hasNulls());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DeltaInstanceTest.java
+++ b/src/catdata/cql/fdm/DeltaInstanceTest.java
@@ -1,0 +1,84 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DeltaInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertEquals(schema.ens, delta.schema().ens);
+    }
+
+    @Test
+    void constructorRejectsSchemasMismatch() {
+      var schema2 = FdmTestHelpers.schemaWithFk();
+      var mapping = FdmTestHelpers.identityMapping(schema2);
+      var inst = FdmTestHelpers.singleElementInstance(); // on schema1
+      assertThrows(RuntimeException.class, () -> new DeltaInstance<>(mapping, inst));
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void algebraReturnsElements() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertEquals(1, delta.algebra().size("E"));
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertNotNull(delta.dp());
+      assertSame(delta, delta.dp()); // implements DP itself
+    }
+
+    @Test
+    void toStringProverDelegates() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertNotNull(delta.toStringProver());
+    }
+
+    @Test
+    void requireConsistencyDelegates() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertFalse(delta.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaDelegates() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var delta = new DeltaInstance<>(mapping, inst);
+      assertFalse(delta.allowUnsafeJava());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DeltaTransformTest.java
+++ b/src/catdata/cql/fdm/DeltaTransformTest.java
@@ -1,0 +1,80 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DeltaTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSrcAndDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DeltaTransform<>(mapping, idTransform);
+      assertNotNull(dt.src());
+      assertNotNull(dt.dst());
+    }
+
+    @Test
+    void constructorRejectsSchemaMismatch() {
+      var schema2 = FdmTestHelpers.schemaWithFk();
+      var mapping = FdmTestHelpers.identityMapping(schema2);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      assertThrows(RuntimeException.class, () -> new DeltaTransform<>(mapping, idTransform));
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DeltaTransform<>(mapping, idTransform);
+      assertNotNull(dt.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DeltaTransform<>(mapping, idTransform);
+      assertNotNull(dt.sks());
+    }
+
+    @Test
+    void srcIsDeltaInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DeltaTransform<>(mapping, idTransform);
+      assertTrue(dt.src() instanceof DeltaInstance);
+    }
+
+    @Test
+    void dstIsDeltaInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DeltaTransform<>(mapping, idTransform);
+      assertTrue(dt.dst() instanceof DeltaInstance);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DiffInstanceTest.java
+++ b/src/catdata/cql/fdm/DiffInstanceTest.java
@@ -1,0 +1,84 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DiffInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorRejectsSchemaWithFks() {
+      var inst1 = FdmTestHelpers.instanceWithFk();
+      var inst2 = FdmTestHelpers.instanceWithFk();
+      assertThrows(RuntimeException.class,
+          () -> new DiffInstance<>(inst1, inst2, false, false));
+    }
+
+    @Test
+    void constructorRejectsDifferentSchemas() {
+      var schema1 = FdmTestHelpers.singleEntitySchema();
+      var schema2 = FdmTestHelpers.emptySchema();
+      var inst1 = FdmTestHelpers.emptyInstance(schema1);
+      var inst2 = FdmTestHelpers.emptyInstance(schema2);
+      assertThrows(RuntimeException.class,
+          () -> new DiffInstance<>(inst1, inst2, false, false));
+    }
+  }
+
+  @Nested
+  class DiffBehavior {
+
+    @Test
+    void diffOfSameInstanceIsEmpty() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var diff = new DiffInstance<>(inst, inst, false, false);
+      assertEquals(0, diff.algebra().size("E"));
+    }
+
+    @Test
+    void diffWithEmptyKeepsAll() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var inst = FdmTestHelpers.singleElementInstance();
+      var empty = FdmTestHelpers.emptyInstance(schema);
+      var diff = new DiffInstance<>(inst, empty, false, false);
+      assertEquals(1, diff.algebra().size("E"));
+    }
+  }
+
+  @Nested
+  class InstanceMethods {
+
+    @Test
+    void schemaMatchesInput() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var inst = FdmTestHelpers.singleElementInstance();
+      var empty = FdmTestHelpers.emptyInstance(schema);
+      var diff = new DiffInstance<>(inst, empty, false, false);
+      assertEquals(schema.ens, diff.schema().ens);
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var inst = FdmTestHelpers.singleElementInstance();
+      var empty = FdmTestHelpers.emptyInstance(schema);
+      var diff = new DiffInstance<>(inst, empty, false, false);
+      assertNotNull(diff.dp());
+    }
+
+    @Test
+    void transformIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var inst = FdmTestHelpers.singleElementInstance();
+      var empty = FdmTestHelpers.emptyInstance(schema);
+      var diff = new DiffInstance<>(inst, empty, false, false);
+      assertNotNull(diff.h);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DistinctInstanceParallelTest.java
+++ b/src/catdata/cql/fdm/DistinctInstanceParallelTest.java
@@ -1,0 +1,74 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class DistinctInstanceParallelTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.schema().ens, distinct.schema().ens);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void gensDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertNotNull(distinct.gens());
+    }
+
+    @Test
+    void sksDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertNotNull(distinct.sks());
+    }
+
+    @Test
+    void algebraSizePreservedOrReduced() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertTrue(distinct.algebra().size("E") <= inst.algebra().size("E"));
+    }
+
+    @Test
+    void requireConsistencyDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.requireConsistency(), distinct.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.allowUnsafeJava(), distinct.allowUnsafeJava());
+    }
+  }
+
+  @Nested
+  class EqsMethod {
+
+    @Test
+    void eqsDoesNotThrow() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstanceParallel<>(inst, AqlOptions.initialOptions);
+      distinct.eqs((l, r) -> {});
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DistinctInstanceTest.java
+++ b/src/catdata/cql/fdm/DistinctInstanceTest.java
@@ -1,0 +1,83 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class DistinctInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.schema().ens, distinct.schema().ens);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void gensDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertNotNull(distinct.gens());
+    }
+
+    @Test
+    void sksDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertNotNull(distinct.sks());
+    }
+
+    @Test
+    void dpRejectsNonGroundEquation() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      var dp = distinct.dp();
+      assertNotNull(dp.toStringProver());
+    }
+
+    @Test
+    void algebraSizePreservedOrReduced() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertTrue(distinct.algebra().size("E") <= inst.algebra().size("E"));
+    }
+
+    @Test
+    void requireConsistencyDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.requireConsistency(), distinct.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      assertEquals(inst.allowUnsafeJava(), distinct.allowUnsafeJava());
+    }
+  }
+
+  @Nested
+  class EqsMethod {
+
+    @Test
+    void eqsIncludesOriginalEquations() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var distinct = new DistinctInstance<>(inst, AqlOptions.initialOptions);
+      // eqs should not throw
+      distinct.eqs((l, r) -> {});
+    }
+  }
+}

--- a/src/catdata/cql/fdm/DistinctTransformTest.java
+++ b/src/catdata/cql/fdm/DistinctTransformTest.java
@@ -1,0 +1,46 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class DistinctTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesSrcAndDst() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DistinctTransform<>(idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertTrue(dt.src() instanceof DistinctInstance);
+      assertTrue(dt.dst() instanceof DistinctInstance);
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void gensDelegatesToWrapped() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DistinctTransform<>(idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(dt.gens());
+    }
+
+    @Test
+    void sksDelegatesToWrapped() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var dt = new DistinctTransform<>(idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(dt.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/EvalAlgebraTest.java
+++ b/src/catdata/cql/fdm/EvalAlgebraTest.java
@@ -1,0 +1,54 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class EvalAlgebraTest {
+
+  @Nested
+  class ViaEvalInstance {
+
+    @Test
+    void algebraSchemaMatchesQuery() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertEquals(schema.ens, eval.algebra().schema().ens);
+    }
+
+    @Test
+    void algebraEnReturnsElements() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertTrue(eval.algebra().en("E").iterator().hasNext());
+    }
+
+    @Test
+    void algebraSizeMatchesInput() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertEquals(1, eval.algebra().size("E"));
+    }
+
+    @Test
+    void algebraToStringProverNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(eval.algebra().toStringProver());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/EvalInstanceTest.java
+++ b/src/catdata/cql/fdm/EvalInstanceTest.java
@@ -1,0 +1,75 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class EvalInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertEquals(schema.ens, eval.schema().ens);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void algebraIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(eval.algebra());
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(eval.dp());
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(eval.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertNotNull(eval.sks());
+    }
+
+    @Test
+    void algebraPreservesSize() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var eval = new EvalInstance<>(query, inst, AqlOptions.initialOptions);
+      assertEquals(1, eval.algebra().size("E"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/EvalTransformTest.java
+++ b/src/catdata/cql/fdm/EvalTransformTest.java
@@ -1,0 +1,64 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class EvalTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSrcAndDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var eval = new EvalTransform<>(query, idTransform, AqlOptions.initialOptions);
+      assertNotNull(eval.src());
+      assertNotNull(eval.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void srcIsEvalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var eval = new EvalTransform<>(query, idTransform, AqlOptions.initialOptions);
+      assertTrue(eval.src() instanceof EvalInstance);
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var eval = new EvalTransform<>(query, idTransform, AqlOptions.initialOptions);
+      assertNotNull(eval.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var eval = new EvalTransform<>(query, idTransform, AqlOptions.initialOptions);
+      assertNotNull(eval.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/FdmTestHelpers.java
+++ b/src/catdata/cql/fdm/FdmTestHelpers.java
@@ -1,0 +1,264 @@
+package catdata.cql.fdm;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import catdata.Chc;
+import catdata.Pair;
+import catdata.Triple;
+import catdata.cql.AqlJs;
+import catdata.cql.AqlOptions;
+import catdata.cql.DP;
+import catdata.cql.Instance;
+import catdata.cql.Mapping;
+import catdata.cql.Schema;
+import catdata.cql.Term;
+import catdata.cql.TypeSide;
+
+class FdmTestHelpers {
+
+  static TypeSide<String, String> emptyTypeSide() {
+    AqlJs<String, String> js = new AqlJs<>(
+        AqlOptions.initialOptions,
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+    DP<String, Void, String, Void, Void, Void, Void> dp = new DP<>() {
+      @Override
+      public String toStringProver() { return "test"; }
+      @Override
+      public boolean eq(Map<String, Chc<String, Void>> ctx,
+          Term<String, Void, String, Void, Void, Void, Void> lhs,
+          Term<String, Void, String, Void, Void, Void, Void> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+    return new TypeSide<>(Collections.emptySet(), Collections.emptyMap(),
+        Collections.emptySet(), js, dp, AqlOptions.initialOptions);
+  }
+
+  static TypeSide<String, String> simpleTypeSide() {
+    Set<String> tys = new HashSet<>(Arrays.asList("String"));
+    Map<String, String> javaTys = new HashMap<>();
+    javaTys.put("String", "java.lang.String");
+    Map<String, String> javaParsers = new HashMap<>();
+    javaParsers.put("String", "x => x");
+    AqlJs<String, String> js = new AqlJs<>(
+        AqlOptions.initialOptions,
+        Collections.emptyMap(),
+        javaTys,
+        javaParsers,
+        Collections.emptyMap());
+    DP<String, Void, String, Void, Void, Void, Void> dp = new DP<>() {
+      @Override
+      public String toStringProver() { return "test"; }
+      @Override
+      public boolean eq(Map<String, Chc<String, Void>> ctx,
+          Term<String, Void, String, Void, Void, Void, Void> lhs,
+          Term<String, Void, String, Void, Void, Void, Void> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+    return new TypeSide<>(tys, Collections.emptyMap(),
+        Collections.emptySet(), js, dp, AqlOptions.initialOptions);
+  }
+
+  static Schema<String, String, String, String, String> emptySchema() {
+    return Schema.terminal(emptyTypeSide());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  static Schema<String, String, String, String, String> singleEntitySchema() {
+    TypeSide<String, String> ts = emptyTypeSide();
+    DP dp = ts.semantics();
+    return new Schema<>(ts, Collections.singleton("E"),
+        Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptySet(), dp, false);
+  }
+
+  static Schema<String, String, String, String, String> schemaWithAtt() {
+    TypeSide<String, String> ts = simpleTypeSide();
+    Map<String, Pair<String, String>> atts = new HashMap<>();
+    atts.put("name", new Pair<>("E", "String"));
+    DP<String, String, String, String, String, Void, Void> dp = new DP<>() {
+      @Override
+      public String toStringProver() { return "test"; }
+      @Override
+      public boolean eq(Map<String, Chc<String, String>> ctx,
+          Term<String, String, String, String, String, Void, Void> lhs,
+          Term<String, String, String, String, String, Void, Void> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+    return new Schema<>(ts, Collections.singleton("E"),
+        atts, Collections.emptyMap(),
+        Collections.emptySet(), dp, false);
+  }
+
+  static Schema<String, String, String, String, String> schemaWithFk() {
+    TypeSide<String, String> ts = emptyTypeSide();
+    Set<String> ens = new HashSet<>(Arrays.asList("A", "B"));
+    Map<String, Pair<String, String>> fks = new HashMap<>();
+    fks.put("f", new Pair<>("A", "B"));
+    DP<String, String, String, String, String, Void, Void> dp = new DP<>() {
+      @Override
+      public String toStringProver() { return "test"; }
+      @Override
+      public boolean eq(Map<String, Chc<String, String>> ctx,
+          Term<String, String, String, String, String, Void, Void> lhs,
+          Term<String, String, String, String, String, Void, Void> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+    return new Schema<>(ts, ens, Collections.emptyMap(), fks,
+        Collections.emptySet(), dp, false);
+  }
+
+  static Schema<String, String, String, String, String> schemaWithAttAndFk() {
+    TypeSide<String, String> ts = simpleTypeSide();
+    Set<String> ens = Collections.singleton("E");
+    Map<String, Pair<String, String>> atts = new HashMap<>();
+    atts.put("name", new Pair<>("E", "String"));
+    Map<String, Pair<String, String>> fks = new HashMap<>();
+    fks.put("f", new Pair<>("E", "E"));
+    DP<String, String, String, String, String, Void, Void> dp = new DP<>() {
+      @Override
+      public String toStringProver() { return "test"; }
+      @Override
+      public boolean eq(Map<String, Chc<String, String>> ctx,
+          Term<String, String, String, String, String, Void, Void> lhs,
+          Term<String, String, String, String, String, Void, Void> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+    return new Schema<>(ts, ens, atts, fks,
+        Collections.emptySet(), dp, false);
+  }
+
+  static Instance<String, String, String, String, String, String, String, String, String> emptyInstance(
+      Schema<String, String, String, String, String> schema) {
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+
+    for (String en : schema.ens) {
+      ensMap.put(en, Collections.emptyList());
+    }
+    for (String ty : schema.typeSide.tys) {
+      tysMap.put(ty, Collections.emptyList());
+    }
+
+    ImportAlgebra<String, String, String, String, String, String, String> alg =
+        new ImportAlgebra<>(schema,
+            en -> ensMap.get(en), tysMap,
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> x, (ty, y) -> y,
+            true, Collections.emptyList());
+
+    return new SaturatedInstance<>(alg, alg, false, false, false, null);
+  }
+
+  static Instance<String, String, String, String, String, String, String, String, String> singleElementInstance() {
+    Schema<String, String, String, String, String> schema = singleEntitySchema();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("E", Collections.singletonList("e1"));
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+
+    ImportAlgebra<String, String, String, String, String, String, String> alg =
+        new ImportAlgebra<>(schema,
+            en -> ensMap.get(en), tysMap,
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> x, (ty, y) -> y,
+            true, Collections.emptyList());
+
+    return new SaturatedInstance<>(alg, alg, false, false, false, null);
+  }
+
+  static Instance<String, String, String, String, String, String, String, String, String> twoElementInstance() {
+    Schema<String, String, String, String, String> schema = singleEntitySchema();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("E", Arrays.asList("e1", "e2"));
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+
+    ImportAlgebra<String, String, String, String, String, String, String> alg =
+        new ImportAlgebra<>(schema,
+            en -> ensMap.get(en), tysMap,
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> x, (ty, y) -> y,
+            true, Collections.emptyList());
+
+    return new SaturatedInstance<>(alg, alg, false, false, false, null);
+  }
+
+  static Instance<String, String, String, String, String, String, String, String, String> instanceWithAtt() {
+    Schema<String, String, String, String, String> schema = schemaWithAtt();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("E", Collections.singletonList("e1"));
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+    tysMap.put("String", Collections.emptyList());
+
+    Map<String, Term<String, Void, String, Void, Void, Void, String>> e1Atts = new HashMap<>();
+    e1Atts.put("name", Term.Obj("Alice", "String"));
+
+    ImportAlgebra<String, String, String, String, String, String, String> alg =
+        new ImportAlgebra<>(schema,
+            en -> ensMap.get(en), tysMap,
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> e1Atts,
+            (en, x) -> x, (ty, y) -> y,
+            true, Collections.emptyList());
+
+    return new SaturatedInstance<>(alg, alg, false, false, false, null);
+  }
+
+  static Instance<String, String, String, String, String, String, String, String, String> instanceWithFk() {
+    Schema<String, String, String, String, String> schema = schemaWithFk();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("A", Collections.singletonList("a1"));
+    ensMap.put("B", Collections.singletonList("b1"));
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+
+    Map<String, String> a1Fks = new HashMap<>();
+    a1Fks.put("f", "b1");
+
+    ImportAlgebra<String, String, String, String, String, String, String> alg =
+        new ImportAlgebra<>(schema,
+            en -> ensMap.get(en), tysMap,
+            (en, x) -> {
+              if (en.equals("A")) return a1Fks;
+              return Collections.emptyMap();
+            },
+            (en, x) -> Collections.emptyMap(),
+            (en, x) -> x, (ty, y) -> y,
+            true, Collections.emptyList());
+
+    return new SaturatedInstance<>(alg, alg, false, false, false, null);
+  }
+
+  static Mapping<String, String, String, String, String, String, String, String> identityMapping(
+      Schema<String, String, String, String, String> schema) {
+    Map<String, String> ens = new HashMap<>();
+    for (String en : schema.ens) {
+      ens.put(en, en);
+    }
+    Map<String, Pair<String, List<String>>> fks = new HashMap<>();
+    for (String fk : schema.fks.keySet()) {
+      fks.put(fk, new Pair<>(schema.fks.get(fk).first, Collections.singletonList(fk)));
+    }
+    Map<String, Triple<String, String, Term<String, String, String, String, String, Void, Void>>> atts = new HashMap<>();
+    for (String att : schema.atts.keySet()) {
+      atts.put(att, new Triple<>("x", schema.atts.get(att).first,
+          Term.Att(att, Term.Var("x"))));
+    }
+    return new Mapping<>(ens, atts, fks, schema, schema, false);
+  }
+}

--- a/src/catdata/cql/fdm/IdentityTransformTest.java
+++ b/src/catdata/cql/fdm/IdentityTransformTest.java
@@ -1,0 +1,60 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.Term;
+
+class IdentityTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void srcAndDstAreSameWhenOptionalEmpty() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var id = new IdentityTransform<>(inst, Optional.empty());
+      assertSame(id.src(), id.dst());
+    }
+
+    @Test
+    void srcAndDstDifferWhenOptionalPresent() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var inst2 = FdmTestHelpers.singleElementInstance();
+      var id = new IdentityTransform<>(inst, Optional.of(inst2));
+      assertSame(inst, id.src());
+      assertSame(inst2, id.dst());
+    }
+
+    @Test
+    void constructorRejectsNull() {
+      assertThrows(RuntimeException.class,
+          () -> new IdentityTransform<>(null, Optional.empty()));
+    }
+  }
+
+  @Nested
+  class GensAndSks {
+
+    @Test
+    void gensMapsToTermGen() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var id = new IdentityTransform<>(inst, Optional.empty());
+      var result = id.gens().apply("e1", "E");
+      assertEquals(Term.Gen("e1"), result);
+    }
+
+    @Test
+    void sksMapsToTermSk() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var id = new IdentityTransform<>(inst, Optional.empty());
+      var result = id.sks().apply("sk1", "String");
+      assertEquals(Term.Sk("sk1"), result);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ImportAlgebraTest.java
+++ b/src/catdata/cql/fdm/ImportAlgebraTest.java
@@ -1,0 +1,176 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.Term;
+
+class ImportAlgebraTest {
+
+  private ImportAlgebra<String, String, String, String, String, String, String> emptyAlgebra() {
+    var schema = FdmTestHelpers.singleEntitySchema();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("E", Collections.emptyList());
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+    return new ImportAlgebra<>(schema,
+        en -> ensMap.get(en), tysMap,
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> x, (ty, y) -> y,
+        true, Collections.emptyList());
+  }
+
+  private ImportAlgebra<String, String, String, String, String, String, String> singleElementAlgebra() {
+    var schema = FdmTestHelpers.singleEntitySchema();
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    ensMap.put("E", Collections.singletonList("e1"));
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+    return new ImportAlgebra<>(schema,
+        en -> ensMap.get(en), tysMap,
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> x, (ty, y) -> y,
+        true, Collections.emptyList());
+  }
+
+  @Nested
+  class SchemaMethod {
+
+    @Test
+    void schemaReturnsProvidedSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      Map<String, Collection<String>> ensMap = new HashMap<>();
+      ensMap.put("E", Collections.emptyList());
+      var alg = new ImportAlgebra<>(schema,
+          en -> ensMap.get(en), new HashMap<>(),
+          (en, x) -> Collections.emptyMap(),
+          (en, x) -> Collections.emptyMap(),
+          (en, x) -> x, (ty, y) -> y,
+          true, Collections.emptyList());
+      assertSame(schema, alg.schema());
+    }
+  }
+
+  @Nested
+  class EnMethod {
+
+    @Test
+    void enReturnsElementsForEntity() {
+      var alg = singleElementAlgebra();
+      var elements = alg.en("E");
+      assertEquals(1, elements.size());
+      assertTrue(elements.contains("e1"));
+    }
+
+    @Test
+    void enReturnsEmptyForNoElements() {
+      var alg = emptyAlgebra();
+      var elements = alg.en("E");
+      assertTrue(elements.isEmpty());
+    }
+  }
+
+  @Nested
+  class GenMethod {
+
+    @Test
+    void genReturnsItself() {
+      var alg = singleElementAlgebra();
+      assertEquals("e1", alg.gen("e1"));
+    }
+  }
+
+  @Nested
+  class SkMethod {
+
+    @Test
+    void skReturnsTermSk() {
+      var alg = emptyAlgebra();
+      assertEquals(Term.Sk("s1"), alg.sk("s1"));
+    }
+  }
+
+  @Nested
+  class ReprMethod {
+
+    @Test
+    void reprReturnsTermGen() {
+      var alg = singleElementAlgebra();
+      assertEquals(Term.Gen("e1"), alg.repr("E", "e1"));
+    }
+  }
+
+  @Nested
+  class SizeMethod {
+
+    @Test
+    void sizeReturnsElementCount() {
+      assertEquals(0, emptyAlgebra().size("E"));
+      assertEquals(1, singleElementAlgebra().size("E"));
+    }
+  }
+
+  @Nested
+  class NullsAndTypeAlgebra {
+
+    @Test
+    void hasFreeTypeAlgebraWhenNoEqs() {
+      assertTrue(emptyAlgebra().hasFreeTypeAlgebra());
+    }
+
+    @Test
+    void hasNullsWhenSksEmpty() {
+      assertTrue(emptyAlgebra().hasNulls());
+    }
+  }
+
+  @Nested
+  class PrintMethods {
+
+    @Test
+    void printXDelegatesToFunction() {
+      var alg = singleElementAlgebra();
+      assertEquals("e1", alg.printX("E", "e1"));
+    }
+
+    @Test
+    void printYDelegatesToFunction() {
+      var alg = emptyAlgebra();
+      assertEquals("y1", alg.printY("String", "y1"));
+    }
+  }
+
+  @Nested
+  class ToStringProver {
+
+    @Test
+    void toStringProverReturnsExpected() {
+      assertEquals("Import algebra prover", emptyAlgebra().toStringProver());
+    }
+  }
+
+  @Nested
+  class ConstructorValidation {
+
+    @Test
+    void constructorRejectsNullSchema() {
+      assertThrows(RuntimeException.class, () ->
+          new ImportAlgebra<>(null,
+              en -> Collections.emptyList(), new HashMap<>(),
+              (en, x) -> Collections.emptyMap(),
+              (en, x) -> Collections.emptyMap(),
+              (en, x) -> x, (ty, y) -> y,
+              true, Collections.emptyList()));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/InitialAlgebraTest.java
+++ b/src/catdata/cql/fdm/InitialAlgebraTest.java
@@ -1,0 +1,27 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class InitialAlgebraTest {
+
+  @Nested
+  class ViaSigmaInstance {
+
+    @Test
+    void initialAlgebraCreatedBySigma() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      // SigmaInstance internally creates an InitialAlgebra
+      assertNotNull(sigma.algebra());
+      assertTrue(sigma.algebra().size("E") > 0);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/InitialInstanceTest.java
+++ b/src/catdata/cql/fdm/InitialInstanceTest.java
@@ -1,0 +1,94 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class InitialInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var init = new InitialInstance<>(schema);
+      assertSame(schema, init.schema());
+    }
+  }
+
+  @Nested
+  class EmptyBehavior {
+
+    @Test
+    void gensIsEmpty() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertEquals(0, init.gens().size());
+    }
+
+    @Test
+    void sksIsEmpty() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertEquals(0, init.sks().size());
+    }
+
+    @Test
+    void algebraSizeIsZero() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertEquals(0, init.algebra().size("E"));
+    }
+
+    @Test
+    void algebraEnIsEmpty() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertFalse(init.algebra().en("E").iterator().hasNext());
+    }
+
+    @Test
+    void algebraHasFreeTypeAlgebra() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertTrue(init.algebra().hasFreeTypeAlgebra());
+    }
+
+    @Test
+    void algebraHasNoNulls() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertFalse(init.algebra().hasNulls());
+    }
+
+    @Test
+    void requireConsistencyIsTrue() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertTrue(init.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaIsFalse() {
+      var init = new InitialInstance<>(FdmTestHelpers.singleEntitySchema());
+      assertFalse(init.allowUnsafeJava());
+    }
+
+    @Test
+    void dpDelegatesFromSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var init = new InitialInstance<>(schema);
+      assertNotNull(init.dp());
+    }
+  }
+
+  @Nested
+  class OnEmptySchema {
+
+    @Test
+    void initialInstanceOnEmptySchema() {
+      var init = new InitialInstance<>(FdmTestHelpers.emptySchema());
+      assertEquals(0, init.gens().size());
+      assertEquals(0, init.sks().size());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/JdbcPragmaTest.java
+++ b/src/catdata/cql/fdm/JdbcPragmaTest.java
@@ -1,0 +1,30 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JdbcPragmaTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsFields() {
+      var pragma = new JdbcPragma("jdbc:h2:mem:test", Collections.emptyList());
+      assertNotNull(pragma);
+    }
+  }
+
+  @Nested
+  class ToStringMethod {
+
+    @Test
+    void toStringBeforeExecute() {
+      var pragma = new JdbcPragma("jdbc:h2:mem:test", Collections.emptyList());
+      assertNotNull(pragma.toString());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/JsPragmaTest.java
+++ b/src/catdata/cql/fdm/JsPragmaTest.java
@@ -1,0 +1,31 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import catdata.Program;
+import catdata.cql.exp.AqlEnv;
+import catdata.cql.exp.Exp;
+
+class JsPragmaTest {
+
+  @Test
+  void constructorCreatesInstance() {
+    Program<Exp<?>> prog = new Program<>(Collections.emptyList(), "");
+    AqlEnv env = new AqlEnv(prog);
+    var pragma = new JsPragma(Collections.emptyList(), Collections.emptyMap(), env);
+    assertNotNull(pragma);
+  }
+
+  @Test
+  void toStringReturnsEmptyBeforeExecute() {
+    Program<Exp<?>> prog = new Program<>(Collections.emptyList(), "");
+    AqlEnv env = new AqlEnv(prog);
+    var pragma = new JsPragma(Collections.emptyList(), Collections.emptyMap(), env);
+    assertEquals("", pragma.toString());
+  }
+}

--- a/src/catdata/cql/fdm/LazySetTest.java
+++ b/src/catdata/cql/fdm/LazySetTest.java
@@ -1,0 +1,212 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LazySetTest {
+
+  private static LazySet<String> lazyOf(Collection<String> backing, int size) {
+    return new LazySet<>(u -> backing, size);
+  }
+
+  private static LazySet<String> lazyOf(String... items) {
+    List<String> list = new ArrayList<>(Arrays.asList(items));
+    return new LazySet<>(u -> list, items.length);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorDoesNotEvaluateSupplier() {
+      AtomicInteger callCount = new AtomicInteger(0);
+      new LazySet<String>(u -> {
+        callCount.incrementAndGet();
+        return List.of();
+      }, 0);
+      assertEquals(0, callCount.get());
+    }
+  }
+
+  @Nested
+  class SizeAndEmpty {
+
+    @Test
+    void sizeReturnsCachedSize() {
+      LazySet<String> set = new LazySet<>(u -> List.of("a", "b", "c"), 3);
+      assertEquals(3, set.size());
+    }
+
+    @Test
+    void isEmptyTrueWhenSizeZero() {
+      assertTrue(new LazySet<>(u -> List.of(), 0).isEmpty());
+    }
+
+    @Test
+    void isEmptyFalseWhenSizeNonZero() {
+      assertFalse(new LazySet<>(u -> List.of("a"), 1).isEmpty());
+    }
+
+    @Test
+    void sizeDoesNotTriggerInit() {
+      AtomicInteger callCount = new AtomicInteger(0);
+      LazySet<String> set = new LazySet<>(u -> {
+        callCount.incrementAndGet();
+        return List.of();
+      }, 5);
+      set.size();
+      set.isEmpty();
+      assertEquals(0, callCount.get());
+    }
+  }
+
+  @Nested
+  class LazyInitialization {
+
+    @Test
+    void initTriggeredByContains() {
+      AtomicInteger callCount = new AtomicInteger(0);
+      LazySet<String> set = new LazySet<>(u -> {
+        callCount.incrementAndGet();
+        return List.of("a");
+      }, 1);
+      set.contains("a");
+      assertEquals(1, callCount.get());
+    }
+
+    @Test
+    void initOnlyCalledOnce() {
+      AtomicInteger callCount = new AtomicInteger(0);
+      LazySet<String> set = new LazySet<>(u -> {
+        callCount.incrementAndGet();
+        return List.of("a");
+      }, 1);
+      set.contains("a");
+      set.contains("b");
+      set.iterator();
+      assertEquals(1, callCount.get());
+    }
+  }
+
+  @Nested
+  class ContainsMethod {
+
+    @Test
+    void containsReturnsTrueForPresent() {
+      assertTrue(lazyOf("a", "b").contains("a"));
+    }
+
+    @Test
+    void containsReturnsFalseForAbsent() {
+      assertFalse(lazyOf("a", "b").contains("c"));
+    }
+  }
+
+  @Nested
+  class IteratorMethod {
+
+    @Test
+    void iteratorReturnsAllElements() {
+      LazySet<String> set = lazyOf("x", "y", "z");
+      List<String> result = new ArrayList<>();
+      Iterator<String> it = set.iterator();
+      while (it.hasNext()) {
+        result.add(it.next());
+      }
+      assertEquals(List.of("x", "y", "z"), result);
+    }
+  }
+
+  @Nested
+  class ToArrayMethod {
+
+    @Test
+    void toArrayReturnsElements() {
+      Object[] arr = lazyOf("a", "b").toArray();
+      assertArrayEquals(new Object[] {"a", "b"}, arr);
+    }
+
+    @Test
+    void toArrayTypedReturnsElements() {
+      String[] arr = lazyOf("a", "b").toArray(new String[0]);
+      assertArrayEquals(new String[] {"a", "b"}, arr);
+    }
+  }
+
+  @Nested
+  class MutationMethods {
+
+    @Test
+    void addDelegatesToBacking() {
+      List<String> backing = new ArrayList<>(List.of("a"));
+      LazySet<String> set = lazyOf(backing, 1);
+      set.add("b");
+      assertTrue(backing.contains("b"));
+    }
+
+    @Test
+    void removeDelegatesToBacking() {
+      List<String> backing = new ArrayList<>(List.of("a", "b"));
+      LazySet<String> set = lazyOf(backing, 2);
+      set.remove("a");
+      assertFalse(backing.contains("a"));
+    }
+
+    @Test
+    void clearDelegatesToBacking() {
+      List<String> backing = new ArrayList<>(List.of("a", "b"));
+      LazySet<String> set = lazyOf(backing, 2);
+      set.clear();
+      assertTrue(backing.isEmpty());
+    }
+
+    @Test
+    void addAllDelegatesToBacking() {
+      List<String> backing = new ArrayList<>();
+      LazySet<String> set = lazyOf(backing, 0);
+      set.addAll(List.of("x", "y"));
+      assertEquals(List.of("x", "y"), backing);
+    }
+
+    @Test
+    void removeAllDelegatesToBacking() {
+      List<String> backing = new ArrayList<>(List.of("a", "b", "c"));
+      LazySet<String> set = lazyOf(backing, 3);
+      set.removeAll(List.of("a", "c"));
+      assertEquals(List.of("b"), backing);
+    }
+
+    @Test
+    void retainAllDelegatesToBacking() {
+      List<String> backing = new ArrayList<>(List.of("a", "b", "c"));
+      LazySet<String> set = lazyOf(backing, 3);
+      set.retainAll(List.of("b"));
+      assertEquals(List.of("b"), backing);
+    }
+  }
+
+  @Nested
+  class ContainsAllMethod {
+
+    @Test
+    void containsAllReturnsTrueWhenAllPresent() {
+      assertTrue(lazyOf("a", "b", "c").containsAll(List.of("a", "c")));
+    }
+
+    @Test
+    void containsAllReturnsFalseWhenSomeMissing() {
+      assertFalse(lazyOf("a", "b").containsAll(List.of("a", "z")));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/LiteralInstanceTest.java
+++ b/src/catdata/cql/fdm/LiteralInstanceTest.java
@@ -1,0 +1,143 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.Pair;
+import catdata.cql.Algebra;
+import catdata.cql.DP;
+import catdata.cql.Schema;
+import catdata.cql.Term;
+
+class LiteralInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      var inst = new LiteralInstance<>(schema,
+          Collections.emptyMap(), Collections.emptyMap(),
+          Collections.emptyList(), dp, alg, false, false);
+      assertSame(schema, inst.schema());
+    }
+
+    @Test
+    void constructorSetsFlags() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      var inst = new LiteralInstance<>(schema,
+          Collections.emptyMap(), Collections.emptyMap(),
+          Collections.emptyList(), dp, alg, true, true);
+      assertTrue(inst.requireConsistency());
+      assertTrue(inst.allowUnsafeJava());
+    }
+  }
+
+  @Nested
+  class Delegation {
+
+    @Test
+    void gensReturnsProvidedMap() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      Map<String, String> gens = new HashMap<>();
+      gens.put("g1", "E");
+      var inst = new LiteralInstance<>(schema, gens, Collections.emptyMap(),
+          Collections.emptyList(), dp, alg, false, false);
+      assertEquals("E", inst.gens().get("g1"));
+    }
+
+    @Test
+    void dpReturnsProvided() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      var inst = new LiteralInstance<>(schema,
+          Collections.emptyMap(), Collections.emptyMap(),
+          Collections.emptyList(), dp, alg, false, false);
+      assertSame(dp, inst.dp());
+    }
+
+    @Test
+    void algebraReturnsProvided() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      var inst = new LiteralInstance<>(schema,
+          Collections.emptyMap(), Collections.emptyMap(),
+          Collections.emptyList(), dp, alg, false, false);
+      assertSame(alg, inst.algebra());
+    }
+  }
+
+  @Nested
+  class EqsMethod {
+
+    @Test
+    void eqsIteratesOverEquations() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = createEmptyAlgebra(schema);
+      var dp = createTrueDP();
+      Map<String, String> gens = new HashMap<>();
+      gens.put("g1", "E");
+      var eq = new Pair<>(Term.<String, String, String, String, String, String, String>Gen("g1"),
+          Term.<String, String, String, String, String, String, String>Gen("g1"));
+      var inst = new LiteralInstance<>(schema,
+          gens, Collections.emptyMap(),
+          Collections.singletonList(eq), dp, alg, false, false);
+      List<Pair<?, ?>> collected = new ArrayList<>();
+      inst.eqs((l, r) -> collected.add(new Pair<>(l, r)));
+      assertEquals(1, collected.size());
+    }
+  }
+
+  // Helper methods
+
+  private static DP<String, String, String, String, String, String, String> createTrueDP() {
+    return new DP<>() {
+      @Override
+      public String toStringProver() { return "test-dp"; }
+      @Override
+      public boolean eq(Map<String, catdata.Chc<String, String>> ctx,
+          Term<String, String, String, String, String, String, String> lhs,
+          Term<String, String, String, String, String, String, String> rhs) {
+        return lhs.equals(rhs);
+      }
+    };
+  }
+
+  private static Algebra<String, String, String, String, String, String, String, String, String> createEmptyAlgebra(
+      Schema<String, String, String, String, String> schema) {
+    Map<String, Collection<String>> ensMap = new HashMap<>();
+    for (String en : schema.ens) {
+      ensMap.put(en, Collections.emptyList());
+    }
+    Map<String, Collection<String>> tysMap = new HashMap<>();
+    for (String ty : schema.typeSide.tys) {
+      tysMap.put(ty, Collections.emptyList());
+    }
+    return new ImportAlgebra<>(schema,
+        en -> ensMap.get(en), tysMap,
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> Collections.emptyMap(),
+        (en, x) -> x, (ty, y) -> y,
+        true, Collections.emptyList());
+  }
+}

--- a/src/catdata/cql/fdm/LiteralTransformTest.java
+++ b/src/catdata/cql/fdm/LiteralTransformTest.java
@@ -1,0 +1,47 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.Term;
+
+class LiteralTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsFields() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var lt = new LiteralTransform<>(
+          (gen, en) -> Term.Gen(gen),
+          (sk, ty) -> Term.Sk(sk),
+          inst, inst, true);
+      assertSame(inst, lt.src());
+      assertSame(inst, lt.dst());
+    }
+
+    @Test
+    void gensReturnsMappingFunction() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var lt = new LiteralTransform<>(
+          (gen, en) -> Term.Gen(gen),
+          (sk, ty) -> Term.Sk(sk),
+          inst, inst, true);
+      assertEquals(Term.Gen("e1"), lt.gens().apply("e1", "E"));
+    }
+
+    @Test
+    void sksReturnsMappingFunction() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var lt = new LiteralTransform<>(
+          (gen, en) -> Term.Gen(gen),
+          (sk, ty) -> Term.Sk(sk),
+          inst, inst, true);
+      assertEquals(Term.Sk("s1"), lt.sks().apply("s1", "String"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ProcPragmaTest.java
+++ b/src/catdata/cql/fdm/ProcPragmaTest.java
@@ -1,0 +1,30 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProcPragmaTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsFields() {
+      var pragma = new ProcPragma(Collections.emptyList());
+      assertNotNull(pragma);
+    }
+  }
+
+  @Nested
+  class ToStringMethod {
+
+    @Test
+    void toStringBeforeExecute() {
+      var pragma = new ProcPragma(Collections.emptyList());
+      assertNotNull(pragma.toString());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/RowTest.java
+++ b/src/catdata/cql/fdm/RowTest.java
@@ -1,0 +1,285 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class RowTest {
+
+  private static Row<String, Integer, String> emptyRow() {
+    return new Row<>("entity");
+  }
+
+  private static Row<String, Integer, String> singleRow() {
+    return new Row<>(emptyRow(), "a", 1, "entity", "typeA");
+  }
+
+  private static Row<String, Integer, String> multiRow() {
+    Row<String, Integer, String> r = emptyRow();
+    r = new Row<>(r, "a", 1, "entity", "typeA");
+    r = new Row<>(r, "b", 2, "entity", "typeB");
+    return r;
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void emptyRowSetsEn2() {
+      Row<String, Integer, String> row = new Row<>("myEntity");
+      assertEquals("myEntity", row.en2());
+    }
+
+    @Test
+    void fullConstructorSetsFields() {
+      Row<String, Integer, String> tail = emptyRow();
+      Row<String, Integer, String> row = new Row<>(tail, "col", 42, "entity", "type");
+      assertEquals("entity", row.en2());
+      assertEquals("type", row.t);
+      assertEquals(42, row.get("col"));
+    }
+
+    @Test
+    void constructorRejectsNullVariable() {
+      Row<String, Integer, String> tail = emptyRow();
+      assertThrows(RuntimeException.class, () -> new Row<>(tail, null, 1, "entity", "type"));
+    }
+  }
+
+  @Nested
+  class GetMethod {
+
+    @Test
+    void getReturnsValueForMatchingKey() {
+      assertEquals(1, singleRow().get("a"));
+    }
+
+    @Test
+    void getSearchesThroughTail() {
+      Row<String, Integer, String> row = multiRow();
+      assertEquals(1, row.get("a"));
+      assertEquals(2, row.get("b"));
+    }
+
+    @Test
+    void getThrowsForMissingKey() {
+      assertThrows(RuntimeException.class, () -> singleRow().get("nonexistent"));
+    }
+  }
+
+  @Nested
+  class AsMapMethod {
+
+    @Test
+    void emptyRowReturnsEmptyMap() {
+      assertTrue(emptyRow().asMap().isEmpty());
+    }
+
+    @Test
+    void singleRowReturnsOneEntry() {
+      Map<String, Integer> map = singleRow().asMap();
+      assertEquals(1, map.size());
+      assertEquals(1, map.get("a"));
+    }
+
+    @Test
+    void multiRowReturnsAllEntries() {
+      Map<String, Integer> map = multiRow().asMap();
+      assertEquals(2, map.size());
+      assertEquals(1, map.get("a"));
+      assertEquals(2, map.get("b"));
+    }
+
+    @Test
+    void asMapReturnsCachedInstance() {
+      Row<String, Integer, String> row = multiRow();
+      Map<String, Integer> first = row.asMap();
+      Map<String, Integer> second = row.asMap();
+      assertTrue(first == second);
+    }
+  }
+
+  @Nested
+  class MapMethod {
+
+    @Test
+    void mapOnEmptyRowReturnsEmptyRow() {
+      Row<String, String, String> mapped = emptyRow().map((x, t) -> "mapped");
+      assertTrue(mapped.asMap().isEmpty());
+    }
+
+    @Test
+    void mapTransformsValues() {
+      Row<String, String, String> mapped = multiRow().map((x, t) -> "v" + x);
+      assertEquals("v1", mapped.get("a"));
+      assertEquals("v2", mapped.get("b"));
+    }
+
+    @Test
+    void mapPreservesEntity() {
+      Row<String, String, String> mapped = singleRow().map((x, t) -> x.toString());
+      assertEquals("entity", mapped.en2());
+    }
+  }
+
+  @Nested
+  class MkRowMethod {
+
+    @Test
+    void mkRowBuildsFromMaps() {
+      List<String> order = Arrays.asList("x", "y");
+      Map<String, Integer> values = new HashMap<>();
+      values.put("x", 10);
+      values.put("y", 20);
+      Map<String, String> types1 = new HashMap<>();
+      types1.put("x", "Int");
+      Map<String, String> types2 = new HashMap<>();
+      types2.put("y", "String");
+
+      Row<String, Integer, String> row = Row.mkRow(order, values, "e", types1, types2);
+      assertEquals(10, row.get("x"));
+      assertEquals(20, row.get("y"));
+      assertEquals("e", row.en2());
+    }
+
+    @Test
+    void mkRowFallsBackToCtx3ForType() {
+      List<String> order = Arrays.asList("a");
+      Map<String, Integer> values = new HashMap<>();
+      values.put("a", 5);
+      Map<String, String> types1 = new HashMap<>();
+      Map<String, String> types2 = new HashMap<>();
+      types2.put("a", "FallbackType");
+
+      Row<String, Integer, String> row = Row.mkRow(order, values, "e", types1, types2);
+      assertEquals("FallbackType", row.t);
+    }
+
+    @Test
+    void mkRowEmptyOrderReturnsEmptyRow() {
+      Row<String, Integer, String> row = Row.mkRow(
+          List.of(), new HashMap<>(), "e", new HashMap<>(), new HashMap<>());
+      assertTrue(row.asMap().isEmpty());
+    }
+  }
+
+  @Nested
+  class ToStringMethod {
+
+    @Test
+    void emptyRowToStringIsEmpty() {
+      assertEquals("", emptyRow().toString());
+    }
+
+    @Test
+    void singleRowToStringShowsKeyValue() {
+      assertEquals("(a=1)", singleRow().toString());
+    }
+
+    @Test
+    void multiRowToStringShowsAllPairs() {
+      String str = multiRow().toString();
+      assertTrue(str.contains("(a=1)"));
+      assertTrue(str.contains("(b=2)"));
+    }
+
+    @Test
+    void toStringWithFunctionAppliesTransform() {
+      String str = singleRow().toString(x -> "[" + x + "]");
+      assertTrue(str.contains("[1]"));
+    }
+  }
+
+  @Nested
+  class EqualsAndHashCode {
+
+    @Test
+    void equalRowsAreEqual() {
+      assertEquals(singleRow(), singleRow());
+    }
+
+    @Test
+    void differentValuesNotEqual() {
+      Row<String, Integer, String> a = new Row<>(emptyRow(), "a", 1, "entity", "typeA");
+      Row<String, Integer, String> b = new Row<>(emptyRow(), "a", 99, "entity", "typeA");
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    void differentEntitiesNotEqual() {
+      Row<String, Integer, String> a = new Row<>("e1");
+      Row<String, Integer, String> b = new Row<>("e2");
+      assertNotEquals(a, b);
+    }
+
+    @Test
+    void equalRowsHaveSameHashCode() {
+      assertEquals(singleRow().hashCode(), singleRow().hashCode());
+    }
+
+    @Test
+    void notEqualToNull() {
+      assertNotEquals(null, singleRow());
+    }
+
+    @Test
+    void equalToSelf() {
+      Row<String, Integer, String> row = singleRow();
+      assertEquals(row, row);
+    }
+
+    @Test
+    void notEqualToDifferentType() {
+      assertFalse(singleRow().equals("not a row"));
+    }
+  }
+
+  @Nested
+  class RowEqualsMethod {
+
+    @Test
+    void rowEqualsWithSameValues() {
+      assertTrue(singleRow().rowEquals((a, b) -> a.equals(b), singleRow()));
+    }
+
+    @Test
+    void rowEqualsWithCustomPredicate() {
+      Row<String, Integer, String> a = new Row<>(emptyRow(), "a", 1, "entity", "typeA");
+      Row<String, Integer, String> b = new Row<>(emptyRow(), "a", 2, "entity", "typeA");
+      assertTrue(a.rowEquals((x, y) -> true, b));
+      assertFalse(a.rowEquals((x, y) -> false, b));
+    }
+
+    @Test
+    void rowEqualsReturnsFalseForDifferentEntities() {
+      Row<String, Integer, String> a = new Row<>("e1");
+      Row<String, Integer, String> b = new Row<>("e2");
+      assertFalse(a.rowEquals((x, y) -> true, b));
+    }
+
+    @Test
+    void rowEqualsEmptyRowsAreEqual() {
+      Row<String, Integer, String> a = new Row<>("entity");
+      Row<String, Integer, String> b = new Row<>("entity");
+      assertTrue(a.rowEquals((x, y) -> true, b));
+    }
+  }
+
+  @Nested
+  class En2Method {
+
+    @Test
+    void en2ReturnsEntity() {
+      assertEquals("entity", singleRow().en2());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SaturatedInstanceTest.java
+++ b/src/catdata/cql/fdm/SaturatedInstanceTest.java
@@ -1,0 +1,114 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.Term;
+
+class SaturatedInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertEquals(FdmTestHelpers.singleEntitySchema().ens, inst.schema().ens);
+    }
+
+    @Test
+    void constructorSetsConsistencyFlags() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      Map<String, Collection<String>> ensMap = new HashMap<>();
+      ensMap.put("E", Collections.singletonList("e1"));
+      var alg = new ImportAlgebra<>(schema,
+          en -> ensMap.get(en), new HashMap<>(),
+          (en, x) -> Collections.emptyMap(),
+          (en, x) -> Collections.emptyMap(),
+          (en, x) -> x, (ty, y) -> y,
+          true, Collections.emptyList());
+
+      var sat = new SaturatedInstance<>(alg, alg, true, true, false, null);
+      assertTrue(sat.requireConsistency());
+      assertTrue(sat.allowUnsafeJava());
+    }
+  }
+
+  @Nested
+  class GensMethod {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void gensContainsAlgebraElements() {
+      var inst = (SaturatedInstance<String, String, String, String, String, String, String, String, String>)
+          FdmTestHelpers.singleElementInstance();
+      assertEquals("E", inst.gens().get("e1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void gensEntrySetIteratesOverElements() {
+      var inst = (SaturatedInstance<String, String, String, String, String, String, String, String, String>)
+          FdmTestHelpers.singleElementInstance();
+      List<String> elements = new ArrayList<>();
+      inst.gens().entrySet((x, en) -> elements.add(x));
+      assertTrue(elements.contains("e1"));
+    }
+  }
+
+  @Nested
+  class AlgebraMethod {
+
+    @Test
+    void algebraGenReturnsItself() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertEquals("e1", inst.algebra().gen("e1"));
+    }
+
+    @Test
+    void algebraReprReturnsTermGen() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertEquals(Term.Gen("e1"), inst.algebra().repr("E", "e1"));
+    }
+
+    @Test
+    void algebraEnReturnsElements() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      List<String> elements = new ArrayList<>();
+      inst.algebra().en("E").forEach(elements::add);
+      assertEquals(List.of("e1"), elements);
+    }
+
+    @Test
+    void algebraSizeReturnsCount() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertEquals(1, inst.algebra().size("E"));
+    }
+
+    @Test
+    void algebraSkReturnsTermSk() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertEquals(Term.Sk("s1"), inst.algebra().sk("s1"));
+    }
+  }
+
+  @Nested
+  class DPMethod {
+
+    @Test
+    void dpToStringProver() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      assertTrue(inst.dp().toStringProver().contains("Saturated"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaChaseAlgebraTest.java
+++ b/src/catdata/cql/fdm/SigmaChaseAlgebraTest.java
@@ -1,0 +1,81 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.Pair;
+import catdata.cql.AqlOptions;
+
+class SigmaChaseAlgebraTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesAlgebra() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      Map<String, Set<Pair<String, String>>> extra = new HashMap<>();
+      extra.put("E", Collections.emptySet());
+      var alg = new SigmaChaseAlgebra<>(mapping, inst, extra, AqlOptions.initialOptions);
+      assertNotNull(alg);
+    }
+
+    @Test
+    void schemaReturnsMappingDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      Map<String, Set<Pair<String, String>>> extra = new HashMap<>();
+      extra.put("E", Collections.emptySet());
+      var alg = new SigmaChaseAlgebra<>(mapping, inst, extra, AqlOptions.initialOptions);
+      assertEquals(schema.ens, alg.schema().ens);
+    }
+
+    @Test
+    void algebraHasElements() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      Map<String, Set<Pair<String, String>>> extra = new HashMap<>();
+      extra.put("E", Collections.emptySet());
+      var alg = new SigmaChaseAlgebra<>(mapping, inst, extra, AqlOptions.initialOptions);
+      assertEquals(1, alg.size("E"));
+    }
+  }
+
+  @Nested
+  class TheInstance {
+
+    @Test
+    void theInstIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      Map<String, Set<Pair<String, String>>> extra = new HashMap<>();
+      extra.put("E", Collections.emptySet());
+      var alg = new SigmaChaseAlgebra<>(mapping, inst, extra, AqlOptions.initialOptions);
+      assertNotNull(alg.theInst);
+    }
+
+    @Test
+    void theInstSchemaMatchesDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      Map<String, Set<Pair<String, String>>> extra = new HashMap<>();
+      extra.put("E", Collections.emptySet());
+      var alg = new SigmaChaseAlgebra<>(mapping, inst, extra, AqlOptions.initialOptions);
+      assertEquals(schema.ens, alg.theInst.schema().ens);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaDeltaCounitTransformTest.java
+++ b/src/catdata/cql/fdm/SigmaDeltaCounitTransformTest.java
@@ -1,0 +1,57 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class SigmaDeltaCounitTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesTransform() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaCounitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.src());
+      assertNotNull(t.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void dstIsOriginalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaCounitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertSame(inst, t.dst());
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaCounitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaCounitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaDeltaUnitTransformTest.java
+++ b/src/catdata/cql/fdm/SigmaDeltaUnitTransformTest.java
@@ -1,0 +1,57 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class SigmaDeltaUnitTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorCreatesTransform() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaUnitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.src());
+      assertNotNull(t.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void srcIsOriginalInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaUnitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertSame(inst, t.src());
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaUnitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var t = new SigmaDeltaUnitTransform<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(t.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaInstanceTest.java
+++ b/src/catdata/cql/fdm/SigmaInstanceTest.java
@@ -1,0 +1,93 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class SigmaInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSchema() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertEquals(schema.ens, sigma.schema().ens);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void algebraIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(sigma.algebra());
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(sigma.dp());
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(sigma.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertNotNull(sigma.sks());
+    }
+
+    @Test
+    void requireConsistencyDelegates() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertTrue(sigma.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaDelegates() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertTrue(sigma.allowUnsafeJava());
+    }
+
+    @Test
+    void eqsDoesNotThrow() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      sigma.eqs((l, r) -> {});
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaLeftKanAlgebraTest.java
+++ b/src/catdata/cql/fdm/SigmaLeftKanAlgebraTest.java
@@ -1,0 +1,24 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class SigmaLeftKanAlgebraTest {
+
+  @Nested
+  class ViaSigmaInstance {
+
+    @Test
+    void algebraComputesCorrectly() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, AqlOptions.initialOptions);
+      assertEquals(1, sigma.algebra().size("E"));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SigmaTransformTest.java
+++ b/src/catdata/cql/fdm/SigmaTransformTest.java
@@ -1,0 +1,62 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class SigmaTransformTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSrcAndDst() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var sigma = new SigmaTransform<>(mapping, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(sigma.src());
+      assertNotNull(sigma.dst());
+    }
+  }
+
+  @Nested
+  class TransformBehavior {
+
+    @Test
+    void srcIsSigmaInstance() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var sigma = new SigmaTransform<>(mapping, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertTrue(sigma.src() instanceof SigmaInstance);
+    }
+
+    @Test
+    void gensIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var sigma = new SigmaTransform<>(mapping, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(sigma.gens());
+    }
+
+    @Test
+    void sksIsNotNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var idTransform = new IdentityTransform<>(inst, Optional.empty());
+      var sigma = new SigmaTransform<>(mapping, idTransform, AqlOptions.initialOptions, AqlOptions.initialOptions);
+      assertNotNull(sigma.sks());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SkolemInstanceTest.java
+++ b/src/catdata/cql/fdm/SkolemInstanceTest.java
@@ -1,0 +1,90 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SkolemInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorSetsSourceInstance() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertSame(inst, skolem.I);
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void schemaDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertSame(inst.schema(), skolem.schema());
+    }
+
+    @Test
+    void gensDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertNotNull(skolem.gens());
+    }
+
+    @Test
+    void requireConsistencyIsFalse() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertFalse(skolem.requireConsistency());
+    }
+
+    @Test
+    void allowUnsafeJavaIsTrue() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertTrue(skolem.allowUnsafeJava());
+    }
+
+    @Test
+    void dpToStringProver() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertEquals("skolem", skolem.dp().toStringProver());
+    }
+
+    @Test
+    void transIsNotNull() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      assertNotNull(skolem.trans);
+    }
+  }
+
+  @Nested
+  class SksMethod {
+
+    @Test
+    void sksContainsKeyReturnsTrue() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      // sks.containsKey always returns true
+      assertTrue(skolem.sks().containsKey(new catdata.Pair<>("anything", "any")));
+    }
+
+    @Test
+    void sksSizeForNoAtts() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      var skolem = new SkolemInstance<>(inst);
+      // schema has no atts, so sks size is 0
+      assertEquals(0, skolem.sks().size());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SlowInitialAlgebraTest.java
+++ b/src/catdata/cql/fdm/SlowInitialAlgebraTest.java
@@ -1,0 +1,95 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.DP;
+import catdata.cql.Schema;
+
+class SlowInitialAlgebraTest {
+
+  private static Iterator<Integer> freshIterator() {
+    return new Iterator<>() {
+      int i = 0;
+
+      @Override
+      public boolean hasNext() {
+        return true;
+      }
+
+      @Override
+      public Integer next() {
+        return i++;
+      }
+    };
+  }
+
+  private static <Gen, Sk> SlowInitialAlgebra<String, String, String, String, String, Gen, Sk, Integer> create(
+      Schema<String, String, String, String, String> schema,
+      Map<Gen, String> gens, Map<Sk, String> sks) {
+    DP<String, String, String, String, String, Gen, Sk> dp = schema.dp();
+    return new SlowInitialAlgebra<>(
+        u -> dp,
+        schema,
+        gens,
+        sks,
+        Collections.emptyList(),
+        freshIterator(),
+        g -> g.toString(),
+        s -> s.toString(),
+        AqlOptions.initialOptions);
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorWithEmptyGenerators() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = create(schema, Collections.emptyMap(), Collections.emptyMap());
+      assertNotNull(alg);
+    }
+
+    @Test
+    void schemaReturnsProvided() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = create(schema, Collections.emptyMap(), Collections.emptyMap());
+      assertEquals(schema, alg.schema());
+    }
+
+    @Test
+    void emptyGeneratorsProducesEmptyEntity() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = create(schema, Collections.emptyMap(), Collections.emptyMap());
+      assertTrue(alg.en("E").isEmpty());
+    }
+  }
+
+  @Nested
+  class WithGenerators {
+
+    @Test
+    void singleGeneratorProducesOneElement() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      Map<String, String> gens = Collections.singletonMap("g1", "E");
+      var alg = create(schema, gens, Collections.emptyMap());
+      assertEquals(1, alg.en("E").size());
+    }
+
+    @Test
+    void hasNullsReturnsTrueWhenNoSkolems() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var alg = create(schema, Collections.emptyMap(), Collections.emptyMap());
+      assertTrue(alg.hasNulls());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/SubInstanceTest.java
+++ b/src/catdata/cql/fdm/SubInstanceTest.java
@@ -1,0 +1,126 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.Pair;
+import catdata.cql.AqlOptions;
+
+class SubInstanceTest {
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void constructorWithFullSetPreservesAll() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertEquals(1, sub.algebra().size("E"));
+    }
+
+    @Test
+    void constructorWithEmptySetCreatesEmpty() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = Collections.emptySet();
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertEquals(0, sub.algebra().size("E"));
+    }
+  }
+
+  @Nested
+  class InstanceBehavior {
+
+    @Test
+    void schemaDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertEquals(inst.schema().ens, sub.schema().ens);
+    }
+
+    @Test
+    void sksDelegates() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertNotNull(sub.sks());
+    }
+
+    @Test
+    void dpIsNotNull() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertNotNull(sub.dp());
+    }
+  }
+
+  @Nested
+  class GensMethod {
+
+    @Test
+    void gensContainsKeyForIncludedElement() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertTrue(sub.gens().containsKey(new Pair<>("E", "e1")));
+    }
+
+    @Test
+    void gensGetReturnsEntity() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertEquals("E", sub.gens().get(new Pair<>("E", "e1")));
+    }
+
+    @Test
+    void gensSizeMatchesSubset() {
+      var inst = FdmTestHelpers.twoElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      assertEquals(1, sub.gens().size());
+    }
+  }
+
+  @Nested
+  class GetInclusionMethod {
+
+    @Test
+    void inclusionSourceIsSubInstance() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      var inclusion = sub.getInclusion();
+      assertSame(sub, inclusion.src());
+    }
+
+    @Test
+    void inclusionDestIsOriginal() {
+      var inst = FdmTestHelpers.singleElementInstance();
+      Set<Pair<String, String>> xs = new HashSet<>();
+      xs.add(new Pair<>("E", "e1"));
+      var sub = new SubInstance<>(xs, inst, AqlOptions.initialOptions);
+      var inclusion = sub.getInclusion();
+      assertSame(inst, inclusion.dst());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/TalgSimplifierTest.java
+++ b/src/catdata/cql/fdm/TalgSimplifierTest.java
@@ -1,0 +1,24 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TalgSimplifierTest {
+
+  @Nested
+  class ToTermMethod {
+
+    @Test
+    void toTermWithObjHead() {
+      // Create a TalgSimplifier indirectly through SigmaInstance, then test toTerm
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var mapping = FdmTestHelpers.identityMapping(schema);
+      var inst = FdmTestHelpers.singleElementInstance();
+      var sigma = new SigmaInstance<>(mapping, inst, catdata.cql.AqlOptions.initialOptions);
+      // TalgSimplifier is used internally; verify the algebra works
+      assertNotNull(sigma.algebra());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ToCsvPragmaInstanceTest.java
+++ b/src/catdata/cql/fdm/ToCsvPragmaInstanceTest.java
@@ -1,0 +1,21 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class ToCsvPragmaInstanceTest {
+
+  @Nested
+  class GetFormatMethod {
+
+    @Test
+    void getFormatReturnsNonNull() {
+      var format = ToCsvPragmaInstance.getFormat(AqlOptions.initialOptions);
+      assertNotNull(format);
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ToCsvPragmaTransformTest.java
+++ b/src/catdata/cql/fdm/ToCsvPragmaTransformTest.java
@@ -1,0 +1,33 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+
+class ToCsvPragmaTransformTest {
+
+  @Nested
+  class GetFormat {
+
+    @Test
+    void getFormatReturnsNonNull() {
+      var format = ToCsvPragmaInstance.getFormat(AqlOptions.initialOptions);
+      assertNotNull(format);
+    }
+
+    @Test
+    void getFormatHasDelimiterString() {
+      var format = ToCsvPragmaInstance.getFormat(AqlOptions.initialOptions);
+      assertNotNull(format.getDelimiterString());
+    }
+
+    @Test
+    void getFormatHasQuoteChar() {
+      var format = ToCsvPragmaInstance.getFormat(AqlOptions.initialOptions);
+      assertNotNull(format.getQuoteCharacter());
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ToExcelPragmaInstanceTest.java
+++ b/src/catdata/cql/fdm/ToExcelPragmaInstanceTest.java
@@ -1,0 +1,20 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ToExcelPragmaInstanceTest {
+
+  @Test
+  void classCanBeLoaded() throws ClassNotFoundException {
+    Class<?> clazz = Class.forName("catdata.cql.fdm.ToExcelPragmaInstance");
+    assertEquals("ToExcelPragmaInstance", clazz.getSimpleName());
+  }
+
+  @Test
+  void classExtendsPragma() {
+    assertTrue(catdata.cql.Pragma.class.isAssignableFrom(ToExcelPragmaInstance.class));
+  }
+}

--- a/src/catdata/cql/fdm/ToJdbcPragmaInstanceTest.java
+++ b/src/catdata/cql/fdm/ToJdbcPragmaInstanceTest.java
@@ -1,0 +1,20 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ToJdbcPragmaInstanceTest {
+
+  @Test
+  void classCanBeLoaded() throws ClassNotFoundException {
+    Class<?> clazz = Class.forName("catdata.cql.fdm.ToJdbcPragmaInstance");
+    assertEquals("ToJdbcPragmaInstance", clazz.getSimpleName());
+  }
+
+  @Test
+  void classExtendsPragma() {
+    assertTrue(catdata.cql.Pragma.class.isAssignableFrom(ToJdbcPragmaInstance.class));
+  }
+}

--- a/src/catdata/cql/fdm/ToJdbcPragmaQueryTest.java
+++ b/src/catdata/cql/fdm/ToJdbcPragmaQueryTest.java
@@ -1,0 +1,64 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import catdata.cql.AqlOptions;
+import catdata.cql.Query;
+
+class ToJdbcPragmaQueryTest {
+
+  @Nested
+  class ToSQLViewsMethod {
+
+    @Test
+    void toSQLViewsReturnsNonNull() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var result = ToJdbcPragmaQuery.toSQLViews("src_", "dst_", "id", "VARCHAR(255)", "\"", query, 255);
+      assertNotNull(result);
+      assertNotNull(result.first);
+      assertNotNull(result.second);
+    }
+
+    @Test
+    void toSQLViewsGeneratesSQLStatements() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var result = ToJdbcPragmaQuery.toSQLViews("src_", "dst_", "id", "VARCHAR(255)", "\"", query, 255);
+      assertFalse(result.first.isEmpty());
+    }
+
+    @Test
+    void toSQLViewsGeneratesDropAndCreate() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var result = ToJdbcPragmaQuery.toSQLViews("src_", "dst_", "id", "VARCHAR(255)", "\"", query, 255);
+      assertEquals(2, result.first.size());
+      assertTrue(result.first.get(0).contains("drop view"));
+      assertTrue(result.first.get(1).contains("create view"));
+    }
+
+    @Test
+    void toSQLViewsPopulatesSecondMap() {
+      var schema = FdmTestHelpers.singleEntitySchema();
+      var query = Query.id(AqlOptions.initialOptions, schema, schema);
+      var result = ToJdbcPragmaQuery.toSQLViews("src_", "dst_", "id", "VARCHAR(255)", "\"", query, 255);
+      assertTrue(result.second.containsKey("E"));
+    }
+  }
+
+  @Nested
+  class ClassStructure {
+
+    @Test
+    void classExtendsPragma() {
+      assertTrue(catdata.cql.Pragma.class.isAssignableFrom(ToJdbcPragmaQuery.class));
+    }
+  }
+}

--- a/src/catdata/cql/fdm/ToJdbcPragmaTransformTest.java
+++ b/src/catdata/cql/fdm/ToJdbcPragmaTransformTest.java
@@ -1,0 +1,20 @@
+package catdata.cql.fdm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ToJdbcPragmaTransformTest {
+
+  @Test
+  void classCanBeLoaded() throws ClassNotFoundException {
+    Class<?> clazz = Class.forName("catdata.cql.fdm.ToJdbcPragmaTransform");
+    assertEquals("ToJdbcPragmaTransform", clazz.getSimpleName());
+  }
+
+  @Test
+  void classExtendsPragma() {
+    assertTrue(catdata.cql.Pragma.class.isAssignableFrom(ToJdbcPragmaTransform.class));
+  }
+}


### PR DESCRIPTION
Two earlier PRs added unit-test coverage:

- [#96 — `ci/quality-checks`](https://github.com/CategoricalData/CQL/pull/96) (CI scaffolding: Checkstyle/SpotBugs/Spotless + workflow)
- [#97 — `test/apg-coverage`](https://github.com/CategoricalData/CQL/pull/97) (`catdata/apg/*` tests)
- [#100 — `test/cql-fdm-coverage`](https://github.com/CategoricalData/CQL/pull/100) (`catdata/cql/fdm/*` tests)

All three were merged to `master`.

## What went wrong

The tests broke Eclipse / bare-`javac` build!!
CQL uses a flat layout where `src/` itself is the single source root (sources live at `src/catdata/...`). The new tests were placed under `src/test/...` (aiming to reproduce the folder structure of the project):
- Gradle, configured with two source roots, accepted this
- Eclipse (single `src/` root) and bare `javac` from the project root flagged it as a path/package mismatch.

## Solution

Tests moved next to the code they exercise, distinguished by file-name suffix (`*Test.java`, `*TestHelpers.java`) — e.g. `src/catdata/cql/fdm/ImportAlgebraTest.java`. Package declarations already matched, so no source edits were needed.

This PR also adds a build step to the ci, that way we can catch potential compiling issues before code is merged