### PR TITLE
fix/build aqlhelp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
   contents: read
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Compile
@@ -75,8 +75,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew checkstyleMain
@@ -96,8 +96,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
 
       - name: Compile main sources with javac
         run: |
@@ -116,8 +116,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew spotbugsMain
@@ -128,4 +128,49 @@ jobs:
         with:
           name: spotbugs-report
           path: build/reports/spotbugs/
+          retention-days: 14
+
+  spotless:
+    name: Spotless (format)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew spotlessCheck
+
+  docs:
+    name: Docs (AqlHelp)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate CQL manual
+        run: ./gradlew generateHelp
+
+      - name: Verify docs generated properly
+        run: |
+          set -euo pipefail
+          test -d help || { echo "::error::help/ was not produced"; exit 1; }
+          for f in index.html syntax.html options.html examples.html logo.html; do
+            test -s "help/$f" || { echo "::error::missing or empty help/$f"; exit 1; }
+          done
+
+      - name: Upload generated docs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cql-manual
+          path: help/
           retention-days: 14

--- a/build.gradle
+++ b/build.gradle
@@ -100,16 +100,33 @@ jacocoTestCoverageVerification {
 
 // --- Spotless (formatting) ---
 spotless {
-    // Only check files that changed vs HEAD — won't flag existing unformatted code
-    ratchetFrom 'HEAD'
+    // Only check files that changed vs a baseline — won't flag the existing unformatted
+    // codebase. Locally, ratchet against HEAD (your uncommitted changes). In CI, a clean
+    // checkout has no diff vs HEAD, so ratchet against the base branch to check what the
+    // PR actually changed. GitHub Actions sets CI=true.
+    ratchetFrom(System.getenv('CI') ? 'origin/master' : 'HEAD')
     java {
         target 'src/**/*.java'
         targetExclude '**/*Test.java', '**/*TestHelpers.java', '**/easik/**', '**/com/**', '**/OilExample.java'
-        googleJavaFormat()
+        googleJavaFormat('1.25.2')
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
     }
+}
+
+// --- Documentation generation ---
+// Runs AqlHelp.main, which generates the CQL HTML manual into the help/ directory
+// (relative to the project root). The forked JVM calls System.exit(0) on success.
+tasks.register('generateHelp', JavaExec) {
+    group = 'documentation'
+    description = 'Generates the CQL HTML manual into the help/ directory.'
+    dependsOn 'classes'
+    mainClass = 'catdata.cql.exp.AqlHelp'
+    classpath = sourceSets.main.runtimeClasspath
+    // Examples may touch AWT; force headless so it runs on CI with no display.
+    systemProperty 'java.awt.headless', 'true'
+    jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
 // Git pre-commit hook: runs spotlessCheck before each commit

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ group = 'org.categoricaldata'
 version = '1.0.0'
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    // Keep producing Java 17 bytecode for runtime compatibility.
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
@@ -108,7 +112,7 @@ spotless {
     java {
         target 'src/**/*.java'
         targetExclude '**/*Test.java', '**/*TestHelpers.java', '**/easik/**', '**/com/**', '**/OilExample.java'
-        googleJavaFormat('1.25.2')
+        googleJavaFormat('1.28.0')
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/src/catdata/cql/exp/AqlHelp.java
+++ b/src/catdata/cql/exp/AqlHelp.java
@@ -1,17 +1,5 @@
 package catdata.cql.exp;
 
-import java.io.File;
-import java.io.FileReader;
-import java.net.URI;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import catdata.Pair;
 import catdata.Program;
 import catdata.Unit;
@@ -28,10 +16,22 @@ import catdata.ide.Examples;
 import catdata.ide.Language;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
+import java.io.File;
+import java.io.FileReader;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AqlHelp {
 
-	static String xxx = """
+  static String xxx =
+      """
 			Associated with each object is a size, according to its kind:
 			  - command and constraints: length of the text string
 			  - instance: number of rows in the tables
@@ -41,562 +41,655 @@ public class AqlHelp {
 			  - mapping and transform and query: size of source
 			""";
 
-	private static String allProver() {
-		StringBuffer sb = new StringBuffer();
-		for (ProverName p : Util.alphabetical(Arrays.asList(ProverName.class.getEnumConstants()))) {
-			sb.append(p.name() + " : " + getProverText(p) + "\n\n");
-		}
-		return sb.toString();
-	}
+  private static String allProver() {
+    StringBuffer sb = new StringBuffer();
+    for (ProverName p : Util.alphabetical(Arrays.asList(ProverName.class.getEnumConstants()))) {
+      sb.append(p.name() + " : " + getProverText(p) + "\n\n");
+    }
+    return sb.toString();
+  }
 
-	private static String getProverText(ProverName p) {
-		switch (p) {
-		case auto:
-			return "The auto theorem proving method attempts the free, congruence, monoidal, and program methods, in that order.";
-		case completion:
-			return "Applies unfailing (ordered) Knuth-Bendix completion specialized to lexicographic path ordering.  If no completion precedence is given, attempts to infer a precedence using constraint-satisfaction techniques.";
-		case congruence:
-			return "Applies only to ground (variable-free) theories.  Uses the classical Nelson-Oppen congruence-closure-with-union-find algorithm.";
-		case e:
-			return "Uses the E prover.  Must be installed.";
-		case fail:
-			return "Applies to all theories.  Always fails with an exception.";
-		case free:
-			return "Applies only to theories without equations.  Equivalence is implemented as the syntactic equality of two terms.";
-		/* START CLOSED SOURCE */
-		// case jaedmax:
-		// return "Uses the jaedmax prover. Does not work with empty sorts.";
-		// case maedmax:
-		// return "Uses the maedmax prover. Must be installed. Support for maedmax will
-		// be ending in early 2021.";
-		/* END CLOSED SOURCE */
-		case monoidal:
-			return "Applies to theories where all equations are monadic (unary) or ground.  Applies Knuth-Bendix completion specialized to semi-Thue systems.";
-		case program:
-			return "Applies only to weakly orthogonal theories.  Interprets all equations p = q as rewrite rules p -> q if p is syntactically smaller than q and q -> p if q is syntactically smaller than p and symbolically evaluates terms to normal forms.  Fails if an equation cannot be oriented.";
-		case vampire:
-			return "Experimental.";
-		}
-		return Util.anomaly();
-	}
+  private static String getProverText(ProverName p) {
+    switch (p) {
+      case auto:
+        return "The auto theorem proving method attempts the free, congruence, monoidal, and program methods, in that order.";
+      case completion:
+        return "Applies unfailing (ordered) Knuth-Bendix completion specialized to lexicographic path ordering.  If no completion precedence is given, attempts to infer a precedence using constraint-satisfaction techniques.";
+      case congruence:
+        return "Applies only to ground (variable-free) theories.  Uses the classical Nelson-Oppen congruence-closure-with-union-find algorithm.";
+      case e:
+        return "Uses the E prover.  Must be installed.";
+      case fail:
+        return "Applies to all theories.  Always fails with an exception.";
+      case free:
+        return "Applies only to theories without equations.  Equivalence is implemented as the syntactic equality of two terms.";
+      /* START CLOSED SOURCE */
+      // case jaedmax:
+      // return "Uses the jaedmax prover. Does not work with empty sorts.";
+      // case maedmax:
+      // return "Uses the maedmax prover. Must be installed. Support for maedmax will
+      // be ending in early 2021.";
+      /* END CLOSED SOURCE */
+      case monoidal:
+        return "Applies to theories where all equations are monadic (unary) or ground.  Applies Knuth-Bendix completion specialized to semi-Thue systems.";
+      case program:
+        return "Applies only to weakly orthogonal theories.  Interprets all equations p = q as rewrite rules p -> q if p is syntactically smaller than q and q -> p if q is syntactically smaller than p and symbolically evaluates terms to normal forms.  Fails if an equation cannot be oriented.";
+      case vampire:
+        return "Experimental.";
+      default:
+        break;
+    }
+    // Graceful fallback: a prover without a hand-written description must not crash
+    // the whole documentation build. The gap stays visible on the generated page.
+    return "TODO: this prover is not yet documented.";
+  }
 
-	static String getOptionText2(AqlOption op) {
+  static String getOptionText2(AqlOption op) {
 
-		switch (op) {
-		case tinkerpop_host:
-			return "Sets the Tinkerpop hostname.";
-		case tinkerpop_port:
-			return "Sets the Tinkerpop port.";
-		case tinkerpop_graph_name:
-			return "Sets the Tinkerpop graph name.";
-		case bitsy_db_path:
-			return "Sets the Bitsy database file path.";
-		case allow_aggregation_unsafe:
-			return "Enables aggregation, which is not functorial.  Associativity, commutativity, and unitality of the given aggegrates are not checked for those properties by the prover.";
-		case left_bias:
-			return "Use the left-biased schema colimit renaming algorithm.";
-		case fast_consistency_check:
-			return "Use a faster but less accurate conservativity/consistency check.";
-		case static_timeout:
-			return "Timeout to use for spellchecker.";
-		case simplify_names:
-			return "Whether to simplify the names of entities etc in schema colimits.";
-		case prover_simplify_max:
-			return "Before going to the theorem prover, simplify collages less than this size.";
-		case jdbc_quote_char:
-			return "The quote symbol to use in SQL statements around identifiers.  E.g., the backtick in MySQL, or double quote in ANSI spec.";
-		case allow_empty_sorts_unsafe:
-			return "When enabled, allows single-sorted theorem proving methods, which may be unsound.";
-		case allow_java_eqs_unsafe:
-			return "When enabled, allows arbitrary equations involving java typeside symbols.  May induce undefined behavior.";
-		case always_reload:
-			return "When enabled, commands (which can have side effects, like loading data from CSV files) are always executed and are not cached between runs of the CQL program.";
-		case chase_style:
-			return "Either parallel (faster, but uses more space) or leftkan (slower, but uses less space).  Note that parallel will not be compatible with sigma operations such as sigma on transforms, the co-unit, etc.  Parallel is recommended only when data volume is too large for the other algorithms.";
-		case completion_compose:
-			return "Uses the ``compose'' inference rule in Knuth-Bendix completion.";
-		case completion_filter_subsumed:
-			return "Filters out equations that are substitution instances of other equations in Knuth-Bendix completion.";
-		case completion_precedence:
-			return "Defines the precedence to be used for Knuth-Bendix completion.  The list  a b c indicates that a < b < c.  Every symbol in a typeside or schema or instance must appear exactly once in this list.";
-		case completion_sort:
-			return "Sorts the list of critical pairs in Knuth-Bendix completion by length, processing shorter pairs first (but still fairly).";
-		case completion_syntactic_ac:
-			return "Enables special support for associative and commutative operators in Knuth-Bendix completion.";
-		case coproduct_allow_entity_collisions_unsafe:
-			return "The generators and labelled nulls of instances participating in a coproduct are required to be unique.  This option disables the uniqueness check.  It is marked unsafe because it can result in an instance that is not a coproduct, but is rather a coproduct followed by a quotient.";
-		case coproduct_allow_type_collisions_unsafe:
-			return "The generators and labelled nulls of instances participating in a coproduct are required to be unique.  This option disables the uniqueness check.  It is marked unsafe because it can result in an instance that is not a coproduct, but is rather a coproduct followed by a quotient.";
-		case emit_ids:
-			return "When true, emits an ID column.";
-		case csv_escape_char:
-			return "Sets the escape character for use in CSV import/export.";
-		case csv_field_delim_char:
-			return "Sets the field delimiter for use in CSV import/export.";
-		case csv_file_extension:
-			return "Sets the file extension to expect during CSV import.";
-		case csv_generate_ids:
-			return "If no ID column is found, then CQL will create IDs during CSV import.";
-		case csv_import_prefix:
-			return "Controls pre in the CSV file pre + en + ext for entity en.";
-		case csv_prepend_entity:
-			return "In the column mapping for CSV import, controls whether or not to prepend entity names when searching for columns in the CSV file.   After the entity the  import_col_seperator is inserted.  In other words, the attribute en + sep + att in the SQL schema will be mapped to column with header att in the CSV file.";
-		case csv_quote_char:
-			return "Sets the quote character for use in CSV import/export.";
-		case dont_validate_unsafe:
-			return "When enabled, mappings and transforms and queries are not checked to be equality-preserving.  For a query, when true it also disables decision procedure construction for sub-queries.";
-		case dont_verify_is_appropriate_for_prover_unsafe:
-			return "Many provers require that their input equational theories have a certain form (e.g., be unary).  When this option is enabled, this (possibly expensive) condition will not be checked.";
-		case e_path:
-			return "The path the the E executable.";
-		case eval_approx_sql_unsafe:
-			return "Queries executed against instances containing nulls cannot be implemented by translation to SQL due to differences between null semantics in CQL and SQL. When enabled, CQL will execute the generated SQL anyway, leading to an undefined, but quickly computed, answer.";
-		case eval_join_selectivity:
-			return "Sets the join selectivity factor used by the cost metric heuristic for the join order chooser.";
-		case eval_max_plan_depth:
-			return "If enabled, join reordering will be performed on FROM clauses with a number of variables smaller than this number (used to prevent the join ordering chooser from spending forever enumerating huge spaces of plans).";
-		case eval_max_temp_size:
-			return "Sets the maximum size of intermediate tables when executing sub-queries.";
-		case eval_reorder_joins:
-			return "Sets whether or not it is permissible for CQL to choose a join order based on exhaustive order enumeration under a heuristic cost metric.";
-		case eval_sql_persistent_indices:
-			return "Queries executed by translation to SQL can store any computed indicies for future use.";
-		case eval_use_indices:
-			return "Sets whether CQL should automatically index instances along their foreign keys and attributes, to reduce the number of intermediate tuples generated during query evaluation. Also applies to SQL-based execution method.";
-		case eval_use_sql_above:
-			return "If possible, translate CQL queries into SQL and use CQL's built-in SQL database (``H2'')) to execute the query.  The translation process incurs overhead, so this option controls how large input instances have to be before translation is used.";
-		case gui_max_graph_size:
-			return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
-					+ ".  For type sides, (colimit) schemas, mappings, transforms, queries. \n\n" + xxx;
-		case gui_max_string_size:
-			return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
-					+ ".  For commands and constraints." + "\n\n" + xxx;
-		case gui_max_table_size:
-			return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
-					+ ".  For instances." + "\n\n" + xxx;
-		case gui_rows_to_display:
-			return "Sets the maximum number of rows to display per table per instance in the viewer.  (I.e., the table in the viewer is conceptually similar to a SQL LIMIT query for the given number of rows).\n\n"
-					+ xxx;
-		case gui_sample:
-			return "When an object's display is suppressed, when set to to true this will display some sample data in the overflow message.\n\n"
-					+ xxx;
-		case gui_sample_size:
-			return "When an object's display is suppressed, sets how much sample data to display the overflow message.\n\n"
-					+ xxx;
-		case id_column_name:
-			return "Specifies the name of the ID columns for CSV and JDBC import/export.";
-		case import_col_seperator:
-			return "When importing a SQL schema the column c of table t becomes CQL attribute t + sep + c.  This option defines sep.  Also used during CSV import to indicate a similar situation.";
-		case import_dont_check_closure_unsafe:
-			return "When set to true, will skip some validation of the imported data.";
-		case import_missing_is_empty:
-			return "When true missing CSV files are treated as empty, and so are missing SQL queries.";
-		case import_null_on_err_unsafe:
-			return "When true, imported values that throw exceptions when converted into CQL values will be treated as labelled nulls.";
-		case interpret_as_algebra:
-			return "Interprets the set of equations in an instance as being the saturation of a model, similar to JDBC / CSV import.  Enabling this options bypasses the construction of a decision procedure, increasing performance, potentially greatly.";
-		case jdbc_default_class:
-			return "This string will be used in JDBC-related expressions when the JDBC driver class is the empty string.";
-		case jdbc_default_string:
-			return "This string will be used in JDBC-related expressions when the JDBC string is the empty string.";
-		case jdbc_export_truncate_after:
-			return "Truncates column names during SQL export to the given length.";
-		case jdbc_no_distinct_unsafe:
-			return "Used with import_jdbc_all.  Setting to false omits DISTINCTifying the set of rows given to CQL during the import process.  Certain SQL datatypes such as blobs do not support the comparison operation required by DISTINCT.";
-		case jdbc_query_export_convert_type:
-			return "Defines the SQL quasi-type to be used with CONVERT statements when emitting SQL for CQL queries.  A good initial guess is VARCHAR for H2 and CHAR for MySQL.";
-		case js_env_name:
-			return "Defines the name of the CQL environment being constructed for use with the exec_js command.";
-		case maedmax_path:
-			return "do not use";
-		case map_nulls_arbitrarily_unsafe:
-			return "In transform import, specifies whether labelled nulls can be mapped into the target by choosing arbitrarily.";
-		case num_threads:
-			return "Sets the number of threads to be used when running an CQL program.";
-		case prepend_entity_on_ids:
-			return "During import, when enable this will import IDs x as en + sep , where en is the entity for x and sep is import_col_seperator. ";
-		case program_allow_nonconfluence_unsafe:
-			return "Interprets all equations p = q as rewrite rules p -> q regardless of confluence.  Can diverge.";
-		case program_allow_nontermination_unsafe:
-			return "Interprets all equations p = q as rewrite rules p -> q regardless of termination behavior.  Can diverge.";
-		case prover:
-			return "Specifies which theorem prover to use.  The prover string should come from the list below.  Only the completion method has options.  Note that these theorem proving methods are not ``java aware''; to use java typesides, instances ``wrap'' these provers with java simplification.  Provers are:\n\n"
-					+ allProver();
-		case query_remove_redundancy:
-			return "Sets whether redundant joins (i.e., containing a binding v and an equation v = e where v notin e) should be eliminated.  Note that this only has an effect when specified at the top level of a query, not within each block.";
-		case quotient_use_chase:
-			return "In doing instance quotients, determines whether or not to use chase-based algorithm.";
-		case random_seed:
-			return "Sets the random number generator seed.";
-		case require_consistency:
-			return "When enabled, requires CQL instances to be consistent (e.g., to not prove 1=2).  (This is checked at runtime.).  Note: is a conservative approximation to conservativity over the type side, the desired condition.";
-		case simple_query_entity:
-			return "Gives the name of the entity to use in a simple query.";
-		case start_ids_at:
-			return "Specifies the integer to use as the initial integer when exporting data.";
-		case static_typing:
-			return "When disabled, relaxes CQL's nominal typing discipline for colimit instances.";
-		case timeout:
-			return "Causes execution to halt after number seconds.";
-		case toCoQuery_max_term_size:
-			return "Controls the maximum size of the terms to be searched.";
-		case varchar_length:
-			return "Specifies the length of the VARCHAR fields to use for JDBC export.";
-		case completion_unfailing:
-			return "Specify if completion should not fail when encountering rules that don't orient.";
-		case talg_reduction:
-			return "Specifies the number of times to simplify a type algebra.  Used for the display and for export.";
-		case prover_allow_fresh_constants:
-			return "If false, theorem provers will fail when encountering new constants generated from java execution.";
-		case second_prover:
-			return "Prover for the type algebra part of the instance.";
-		case gui_show_atts:
-			return "If true, display attributes in the GUI schema and mapping viewers.";
-		case interpet_as_frozen:
-			return "Interprets an instance as having a lazy decision procedure and algebra.";
-		case diverge_limit:
-			return "The number of foreign keys in a schema above which not to perform the instance literal divergence warning check.";
-		case diverge_warn:
-			return "Stops CQL on instance literals below the divergence limit, that have cyclic schemas without equations and an instance with generators but no equations.";
-		case csv_entity_name:
-			return "The entity name to use for imported CSV files with inferred schemas.";
-		case allow_sql_import_all_unsafe:
-			return "Allows the sql_import_all primitive to be used (can result in unsoundness).";
-		case graal_language:
-			return "Specifies which external language to use with graalvm.";
-		case import_sql_direct_prefix:
-			return "Given prefix P, in import_sql_direct the table P will be selected as prefix + P; e.g the prefix could be INFORMATION_SCHEMA";
-		case jena_reasoner:
-			return "Specifies which Apache JENA OWL Reasoner to use.";
-		case triviality_check_best_effort:
-			return "Specifies whether to make a best effort to determine if particular theories are trivial (prove that all things are equal).";
-		case vampire_path:
-			return "The path to the Vampire executable.";
-		case check_command_export_file:
-			return "The path to export check command failing rows to (JSON)";
-		case active_domain:
-			return "When true, evaluation will loop through the active domains of type";
-		case csv_row_sort_order:
-			return "Comma separated list of columns to use to sort CSV output";
-		case csv_utf8_bom:
-			return "When true, the UTF watermark will be prepended to output CSV files";
-		case e_use_auto:
-			return "When true, invocations of the e prover will use -auto";
-		case is_oracle:
-			return "do not use";
-		case jdbc_zero:
-			return "Specifies which sql query to use in a select statement to obtain a zero.  Works with direct sql import.";
-		case oracle_schema_mode:
-			return "do not use";
-		case sql_constraints_simple:
-			return "do not use";
-	//	default:
-	//		break;
-		case check_warn_instead_of_fail:
-			return "When true, check commans will emit warnings instead of stopping execution";
-		default:
-			break;
+    switch (op) {
+      case tinkerpop_host:
+        return "Sets the Tinkerpop hostname.";
+      case tinkerpop_port:
+        return "Sets the Tinkerpop port.";
+      case tinkerpop_graph_name:
+        return "Sets the Tinkerpop graph name.";
+      case bitsy_db_path:
+        return "Sets the Bitsy database file path.";
+      case allow_aggregation_unsafe:
+        return "Enables aggregation, which is not functorial.  Associativity, commutativity, and unitality of the given aggegrates are not checked for those properties by the prover.";
+      case left_bias:
+        return "Use the left-biased schema colimit renaming algorithm.";
+      case fast_consistency_check:
+        return "Use a faster but less accurate conservativity/consistency check.";
+      case static_timeout:
+        return "Timeout to use for spellchecker.";
+      case simplify_names:
+        return "Whether to simplify the names of entities etc in schema colimits.";
+      case prover_simplify_max:
+        return "Before going to the theorem prover, simplify collages less than this size.";
+      case jdbc_quote_char:
+        return "The quote symbol to use in SQL statements around identifiers.  E.g., the backtick in MySQL, or double quote in ANSI spec.";
+      case allow_empty_sorts_unsafe:
+        return "When enabled, allows single-sorted theorem proving methods, which may be unsound.";
+      case allow_java_eqs_unsafe:
+        return "When enabled, allows arbitrary equations involving java typeside symbols.  May induce undefined behavior.";
+      case always_reload:
+        return "When enabled, commands (which can have side effects, like loading data from CSV files) are always executed and are not cached between runs of the CQL program.";
+      case chase_style:
+        return "Either parallel (faster, but uses more space) or leftkan (slower, but uses less space).  Note that parallel will not be compatible with sigma operations such as sigma on transforms, the co-unit, etc.  Parallel is recommended only when data volume is too large for the other algorithms.";
+      case completion_compose:
+        return "Uses the ``compose'' inference rule in Knuth-Bendix completion.";
+      case completion_filter_subsumed:
+        return "Filters out equations that are substitution instances of other equations in Knuth-Bendix completion.";
+      case completion_precedence:
+        return "Defines the precedence to be used for Knuth-Bendix completion.  The list  a b c indicates that a < b < c.  Every symbol in a typeside or schema or instance must appear exactly once in this list.";
+      case completion_sort:
+        return "Sorts the list of critical pairs in Knuth-Bendix completion by length, processing shorter pairs first (but still fairly).";
+      case completion_syntactic_ac:
+        return "Enables special support for associative and commutative operators in Knuth-Bendix completion.";
+      case coproduct_allow_entity_collisions_unsafe:
+        return "The generators and labelled nulls of instances participating in a coproduct are required to be unique.  This option disables the uniqueness check.  It is marked unsafe because it can result in an instance that is not a coproduct, but is rather a coproduct followed by a quotient.";
+      case coproduct_allow_type_collisions_unsafe:
+        return "The generators and labelled nulls of instances participating in a coproduct are required to be unique.  This option disables the uniqueness check.  It is marked unsafe because it can result in an instance that is not a coproduct, but is rather a coproduct followed by a quotient.";
+      case emit_ids:
+        return "When true, emits an ID column.";
+      case csv_escape_char:
+        return "Sets the escape character for use in CSV import/export.";
+      case csv_field_delim_char:
+        return "Sets the field delimiter for use in CSV import/export.";
+      case csv_file_extension:
+        return "Sets the file extension to expect during CSV import.";
+      case csv_generate_ids:
+        return "If no ID column is found, then CQL will create IDs during CSV import.";
+      case csv_import_prefix:
+        return "Controls pre in the CSV file pre + en + ext for entity en.";
+      case csv_prepend_entity:
+        return "In the column mapping for CSV import, controls whether or not to prepend entity names when searching for columns in the CSV file.   After the entity the  import_col_seperator is inserted.  In other words, the attribute en + sep + att in the SQL schema will be mapped to column with header att in the CSV file.";
+      case csv_quote_char:
+        return "Sets the quote character for use in CSV import/export.";
+      case dont_validate_unsafe:
+        return "When enabled, mappings and transforms and queries are not checked to be equality-preserving.  For a query, when true it also disables decision procedure construction for sub-queries.";
+      case dont_verify_is_appropriate_for_prover_unsafe:
+        return "Many provers require that their input equational theories have a certain form (e.g., be unary).  When this option is enabled, this (possibly expensive) condition will not be checked.";
+      case e_path:
+        return "The path the the E executable.";
+      case eval_approx_sql_unsafe:
+        return "Queries executed against instances containing nulls cannot be implemented by translation to SQL due to differences between null semantics in CQL and SQL. When enabled, CQL will execute the generated SQL anyway, leading to an undefined, but quickly computed, answer.";
+      case eval_join_selectivity:
+        return "Sets the join selectivity factor used by the cost metric heuristic for the join order chooser.";
+      case eval_max_plan_depth:
+        return "If enabled, join reordering will be performed on FROM clauses with a number of variables smaller than this number (used to prevent the join ordering chooser from spending forever enumerating huge spaces of plans).";
+      case eval_max_temp_size:
+        return "Sets the maximum size of intermediate tables when executing sub-queries.";
+      case eval_reorder_joins:
+        return "Sets whether or not it is permissible for CQL to choose a join order based on exhaustive order enumeration under a heuristic cost metric.";
+      case eval_sql_persistent_indices:
+        return "Queries executed by translation to SQL can store any computed indicies for future use.";
+      case eval_use_indices:
+        return "Sets whether CQL should automatically index instances along their foreign keys and attributes, to reduce the number of intermediate tuples generated during query evaluation. Also applies to SQL-based execution method.";
+      case eval_use_sql_above:
+        return "If possible, translate CQL queries into SQL and use CQL's built-in SQL database (``H2'')) to execute the query.  The translation process incurs overhead, so this option controls how large input instances have to be before translation is used.";
+      case gui_max_graph_size:
+        return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
+            + ".  For type sides, (colimit) schemas, mappings, transforms, queries. \n\n"
+            + xxx;
+      case gui_max_string_size:
+        return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
+            + ".  For commands and constraints."
+            + "\n\n"
+            + xxx;
+      case gui_max_table_size:
+        return "The maximum size of such an object to be displayed in the viewer is controlled by the three options below.\n"
+            + ".  For instances."
+            + "\n\n"
+            + xxx;
+      case gui_rows_to_display:
+        return "Sets the maximum number of rows to display per table per instance in the viewer.  (I.e., the table in the viewer is conceptually similar to a SQL LIMIT query for the given number of rows).\n\n"
+            + xxx;
+      case gui_sample:
+        return "When an object's display is suppressed, when set to to true this will display some sample data in the overflow message.\n\n"
+            + xxx;
+      case gui_sample_size:
+        return "When an object's display is suppressed, sets how much sample data to display the overflow message.\n\n"
+            + xxx;
+      case id_column_name:
+        return "Specifies the name of the ID columns for CSV and JDBC import/export.";
+      case import_col_seperator:
+        return "When importing a SQL schema the column c of table t becomes CQL attribute t + sep + c.  This option defines sep.  Also used during CSV import to indicate a similar situation.";
+      case import_dont_check_closure_unsafe:
+        return "When set to true, will skip some validation of the imported data.";
+      case import_missing_is_empty:
+        return "When true missing CSV files are treated as empty, and so are missing SQL queries.";
+      case import_null_on_err_unsafe:
+        return "When true, imported values that throw exceptions when converted into CQL values will be treated as labelled nulls.";
+      case interpret_as_algebra:
+        return "Interprets the set of equations in an instance as being the saturation of a model, similar to JDBC / CSV import.  Enabling this options bypasses the construction of a decision procedure, increasing performance, potentially greatly.";
+      case jdbc_default_class:
+        return "This string will be used in JDBC-related expressions when the JDBC driver class is the empty string.";
+      case jdbc_default_string:
+        return "This string will be used in JDBC-related expressions when the JDBC string is the empty string.";
+      case jdbc_export_truncate_after:
+        return "Truncates column names during SQL export to the given length.";
+      case jdbc_no_distinct_unsafe:
+        return "Used with import_jdbc_all.  Setting to false omits DISTINCTifying the set of rows given to CQL during the import process.  Certain SQL datatypes such as blobs do not support the comparison operation required by DISTINCT.";
+      case jdbc_query_export_convert_type:
+        return "Defines the SQL quasi-type to be used with CONVERT statements when emitting SQL for CQL queries.  A good initial guess is VARCHAR for H2 and CHAR for MySQL.";
+      case js_env_name:
+        return "Defines the name of the CQL environment being constructed for use with the exec_js command.";
+      case maedmax_path:
+        return "do not use";
+      case map_nulls_arbitrarily_unsafe:
+        return "In transform import, specifies whether labelled nulls can be mapped into the target by choosing arbitrarily.";
+      case num_threads:
+        return "Sets the number of threads to be used when running an CQL program.";
+      case prepend_entity_on_ids:
+        return "During import, when enable this will import IDs x as en + sep , where en is the entity for x and sep is import_col_seperator. ";
+      case program_allow_nonconfluence_unsafe:
+        return "Interprets all equations p = q as rewrite rules p -> q regardless of confluence.  Can diverge.";
+      case program_allow_nontermination_unsafe:
+        return "Interprets all equations p = q as rewrite rules p -> q regardless of termination behavior.  Can diverge.";
+      case prover:
+        return "Specifies which theorem prover to use.  The prover string should come from the list below.  Only the completion method has options.  Note that these theorem proving methods are not ``java aware''; to use java typesides, instances ``wrap'' these provers with java simplification.  Provers are:\n\n"
+            + allProver();
+      case query_remove_redundancy:
+        return "Sets whether redundant joins (i.e., containing a binding v and an equation v = e where v notin e) should be eliminated.  Note that this only has an effect when specified at the top level of a query, not within each block.";
+      case quotient_use_chase:
+        return "In doing instance quotients, determines whether or not to use chase-based algorithm.";
+      case random_seed:
+        return "Sets the random number generator seed.";
+      case require_consistency:
+        return "When enabled, requires CQL instances to be consistent (e.g., to not prove 1=2).  (This is checked at runtime.).  Note: is a conservative approximation to conservativity over the type side, the desired condition.";
+      case simple_query_entity:
+        return "Gives the name of the entity to use in a simple query.";
+      case start_ids_at:
+        return "Specifies the integer to use as the initial integer when exporting data.";
+      case static_typing:
+        return "When disabled, relaxes CQL's nominal typing discipline for colimit instances.";
+      case timeout:
+        return "Causes execution to halt after number seconds.";
+      case toCoQuery_max_term_size:
+        return "Controls the maximum size of the terms to be searched.";
+      case varchar_length:
+        return "Specifies the length of the VARCHAR fields to use for JDBC export.";
+      case completion_unfailing:
+        return "Specify if completion should not fail when encountering rules that don't orient.";
+      case talg_reduction:
+        return "Specifies the number of times to simplify a type algebra.  Used for the display and for export.";
+      case prover_allow_fresh_constants:
+        return "If false, theorem provers will fail when encountering new constants generated from java execution.";
+      case second_prover:
+        return "Prover for the type algebra part of the instance.";
+      case gui_show_atts:
+        return "If true, display attributes in the GUI schema and mapping viewers.";
+      case interpet_as_frozen:
+        return "Interprets an instance as having a lazy decision procedure and algebra.";
+      case diverge_limit:
+        return "The number of foreign keys in a schema above which not to perform the instance literal divergence warning check.";
+      case diverge_warn:
+        return "Stops CQL on instance literals below the divergence limit, that have cyclic schemas without equations and an instance with generators but no equations.";
+      case csv_entity_name:
+        return "The entity name to use for imported CSV files with inferred schemas.";
+      case allow_sql_import_all_unsafe:
+        return "Allows the sql_import_all primitive to be used (can result in unsoundness).";
+      case graal_language:
+        return "Specifies which external language to use with graalvm.";
+      case import_sql_direct_prefix:
+        return "Given prefix P, in import_sql_direct the table P will be selected as prefix + P; e.g the prefix could be INFORMATION_SCHEMA";
+      case jena_reasoner:
+        return "Specifies which Apache JENA OWL Reasoner to use.";
+      case triviality_check_best_effort:
+        return "Specifies whether to make a best effort to determine if particular theories are trivial (prove that all things are equal).";
+      case vampire_path:
+        return "The path to the Vampire executable.";
+      case check_command_export_file:
+        return "The path to export check command failing rows to (JSON)";
+      case active_domain:
+        return "When true, evaluation will loop through the active domains of type";
+      case csv_row_sort_order:
+        return "Comma separated list of columns to use to sort CSV output";
+      case csv_utf8_bom:
+        return "When true, the UTF watermark will be prepended to output CSV files";
+      case e_use_auto:
+        return "When true, invocations of the e prover will use -auto";
+      case is_oracle:
+        return "do not use";
+      case jdbc_zero:
+        return "Specifies which sql query to use in a select statement to obtain a zero.  Works with direct sql import.";
+      case oracle_schema_mode:
+        return "do not use";
+      case sql_constraints_simple:
+        return "do not use";
+      //	default:
+      //		break;
+      case check_warn_instead_of_fail:
+        return "When true, check commans will emit warnings instead of stopping execution";
+      default:
+        break;
+    }
 
-		}
+    // Graceful fallback: an option without a hand-written description must not crash
+    // the whole documentation build. The gap stays visible on the generated page.
+    return "TODO: this option is not yet documented.";
+  }
 
-		throw new RuntimeException(op.name());
+  public static String getOptionText(AqlOption op) {
+    Object o = AqlOptions.initialOptions.getOrDefault(op);
+    String s = getOptionText2(op);
+    return "<pre>Default: " + o + "</pre>" + s;
+  }
 
-	}
+  public static void main(String[] args) throws java.io.IOException {
+    File tmp = java.nio.file.Files.createTempDirectory("aqlhelp").toFile();
+    catdata.cql.AqlTester.deleteFilesCreatedDuring(
+        () -> {
+          help(tmp, true);
+          return null; // not used
+        });
+    File help = new File("help");
+    if (help.exists()) {
+      for (File f : help.listFiles()) {
+        f.delete();
+      }
+      help.delete();
+    }
+    tmp.renameTo(help);
+    System.exit(0); // slay daemons
+  }
 
-	public static String getOptionText(AqlOption op) {
-		Object o = AqlOptions.initialOptions.getOrDefault(op);
-		String s = getOptionText2(op);
-		return "<pre>Default: " + o + "</pre>" + s;
-	}
+  @SuppressWarnings("unchecked")
+  public static void help(File dir, boolean run) {
+    try {
+      if (!dir.exists()) {
+        dir.mkdir();
+      }
 
-	public static void main(String[] args) throws java.io.IOException {
-		File tmp = java.nio.file.Files.createTempDirectory("aqlhelp").toFile();
-		catdata.cql.AqlTester.deleteFilesCreatedDuring(() -> {
-			help(tmp, true);
-			return null; // not used
-		});
-		File help = new File("help");
-		if (help.exists()) {
-			for (File f : help.listFiles()) {
-				f.delete();
-			}
-			help.delete();
-		}
-		tmp.renameTo(help);
-		System.exit(0); // slay daemons
-	}
+      String css = "\n<link rel=\"stylesheet\" href=\"../css/nstyle.css\">";
 
-	@SuppressWarnings("unchecked")
-	public static void help(File dir, boolean run) {
-		try {
-			if (!dir.exists()) {
-				dir.mkdir();
-			}
+      /*	String search = "<html><head>\n" + "\n" + css + "\n" + "<div>\n"
+      		+ "  <form action=\"search.php\" method=\"get\">\n"
+      		+ "       <input type=\"text\" name=\"text\" value=<?php echo \"\\\"\" . $_GET[\"text\"] . \"\\\"\" ; ?> > \n"
+      		+ "              <input type=\"submit\" name=\"submit\" value=\"Search\">\n" + "              \n"
+      		+ "              <br>\n" + "    </form>\n" + "\n" + "</div>\n" + "\n" + "\n" + "<?php\n" + "\n"
+      		+ "$string = $_GET[\"text\"];\n" + "\n" + "\n"
+      		+ "if (strpos(file_get_contents('../logo.html'), $string) !== false) {\n"
+      		+ "        echo \"<a href=\\\"../logo.html\\\">CQL Manual</a><br/>\";\n" + "}\n" + "    \n"
+      		+ "$dir = new DirectoryIterator('.');\n" + "foreach ($dir as $file) {\n"
+      		+ "    if ($file == 'search.php') {\n" + "        continue;   \n" + "    }\n"
+      		+ "    if ($file == 'logo.html') {\n" + "        continue;   \n" + "    }\n"
+      		+ "    if ($file == 'options.html') {\n" + "        continue;   \n" + "    }\n"
+      		+ "    if ($file == 'examples.html') {\n" + "        continue;   \n" + "    }\n"
+      		+ "    if ($file == 'syntax.html') {\n" + "        continue;   \n" + "    }\n"
+      		+ "    $content = file_get_contents($file->getPathname());\n" + "    \n"
+      		+ "    if (strpos($content, $string) !== false) {\n"
+      		+ "        echo \"<a href=\\\"\" . $file . \"\\\">\" . $file . \"</a><br/>\";\n" + "    }\n" + "}\n"
+      		+ "\n" + "?>\n" + "\n" + "\n" + "\n" + "</body></html>";
+      Util.writeFile(search, new File(dir, "search.php").getAbsolutePath()); */
+      Map<Example, Set<AqlSyntax>> index = new THashMap<>();
 
-			String css = "\n<link rel=\"stylesheet\" href=\"../css/nstyle.css\">";
+      StringBuffer examples = new StringBuffer("<html><head>" + css + "</head><body>");
+      for (Example ex : Util.alphabetical(Examples.getExamples(Language.CQL))) {
+        if (ex.getName().equals("Stdlib") || ex.getName().equals("TutorialTSP")) {
+          continue;
+        }
+        examples.append(
+            "\n<a href=\""
+                + ex.getName().trim()
+                + ".html\" target=\"primary\">"
+                + ex.getName().trim()
+                + "</a><br />");
 
-		/*	String search = "<html><head>\n" + "\n" + css + "\n" + "<div>\n"
-					+ "  <form action=\"search.php\" method=\"get\">\n"
-					+ "       <input type=\"text\" name=\"text\" value=<?php echo \"\\\"\" . $_GET[\"text\"] . \"\\\"\" ; ?> > \n"
-					+ "              <input type=\"submit\" name=\"submit\" value=\"Search\">\n" + "              \n"
-					+ "              <br>\n" + "    </form>\n" + "\n" + "</div>\n" + "\n" + "\n" + "<?php\n" + "\n"
-					+ "$string = $_GET[\"text\"];\n" + "\n" + "\n"
-					+ "if (strpos(file_get_contents('../logo.html'), $string) !== false) {\n"
-					+ "        echo \"<a href=\\\"../logo.html\\\">CQL Manual</a><br/>\";\n" + "}\n" + "    \n"
-					+ "$dir = new DirectoryIterator('.');\n" + "foreach ($dir as $file) {\n"
-					+ "    if ($file == 'search.php') {\n" + "        continue;   \n" + "    }\n"
-					+ "    if ($file == 'logo.html') {\n" + "        continue;   \n" + "    }\n"
-					+ "    if ($file == 'options.html') {\n" + "        continue;   \n" + "    }\n"
-					+ "    if ($file == 'examples.html') {\n" + "        continue;   \n" + "    }\n"
-					+ "    if ($file == 'syntax.html') {\n" + "        continue;   \n" + "    }\n"
-					+ "    $content = file_get_contents($file->getPathname());\n" + "    \n"
-					+ "    if (strpos($content, $string) !== false) {\n"
-					+ "        echo \"<a href=\\\"\" . $file . \"\\\">\" . $file . \"</a><br/>\";\n" + "    }\n" + "}\n"
-					+ "\n" + "?>\n" + "\n" + "\n" + "\n" + "</body></html>";
-			Util.writeFile(search, new File(dir, "search.php").getAbsolutePath()); */
-			Map<Example, Set<AqlSyntax>> index = new THashMap<>();
+        System.out.println(ex.getName());
+        Program<Exp<?>> prog = new CombinatorParser().parseProgram(ex.getText());
 
-			StringBuffer examples = new StringBuffer("<html><head>" + css + "</head><body>");
-			for (Example ex : Util.alphabetical(Examples.getExamples(Language.CQL))) {
-				if (ex.getName().equals("Stdlib") || ex.getName().equals("TutorialTSP")) {
-					continue;
-				}
-				examples.append("\n<a href=\"" + ex.getName().trim() + ".html\" target=\"primary\">"
-						+ ex.getName().trim() + "</a><br />");
+        StringBuffer other = new StringBuffer();
+        Set<AqlSyntax> set = new THashSet<>();
+        Set<String> opSeen = new THashSet<>();
+        index.put(ex, set);
+        other.append("Keywords:<br/></br>");
+        for (Exp<?> e : prog.exps.values()) {
+          if (!set.contains(e.getSyntax())) {
+            set.add(e.getSyntax());
+            other.append(
+                "\t\t\t<a href=\""
+                    + e.kind()
+                    + e.getKeyword()
+                    + ".html"
+                    + "\" >"
+                    + e.getKeyword()
+                    + "</a><br />\n");
+          }
+          for (String k : e.options().keySet()) {
+            if (opSeen.contains(k)) {
+              continue;
+            }
+            opSeen.add(k);
+          }
+        }
+        other.append("<br/>Options:<br/></br>");
+        for (String x : opSeen) {
+          other.append("<a href=\"" + x + ".html\" >" + x + "</a><br/>\n");
+        }
 
-				System.out.println(ex.getName());
-				Program<Exp<?>> prog = new CombinatorParser().parseProgram(ex.getText());
+        StringBuffer insts = new StringBuffer();
+        if (run) {
+          insts.append("\n");
+          try {
+            AqlMultiDriver dr = new AqlMultiDriver(prog, null);
+            dr.start();
+            for (String k : dr.env.defs.insts.keySet()) {
+              Instance<?, ?, ?, ?, ?, ?, ?, ?, ?> i = dr.env.defs.insts.get(k);
+              insts.append("<hr/>");
+              insts.append("<h3>instance " + k + "</h3>");
+              insts.append(
+                  AqlInACan.toHtml(
+                      dr.env,
+                      (Instance<
+                              String,
+                              String,
+                              catdata.cql.exp.Sym,
+                              catdata.cql.exp.Fk,
+                              catdata.cql.exp.Att,
+                              String,
+                              String,
+                              Object,
+                              Object>)
+                          i));
+            }
+            for (String k : dr.env.defs.ps.keySet()) {
+              Pragma i = dr.env.defs.ps.get(k);
+              insts.append("<hr/>");
+              insts.append("<h3>command " + k + "</h3><pre>");
+              insts.append(i.toString());
+              insts.append("</pre>");
+            }
+          } catch (Exception exe) {
+            exe.printStackTrace();
+          }
+        }
 
-				StringBuffer other = new StringBuffer();
-				Set<AqlSyntax> set = new THashSet<>();
-				Set<String> opSeen = new THashSet<>();
-				index.put(ex, set);
-				other.append("Keywords:<br/></br>");
-				for (Exp<?> e : prog.exps.values()) {
-					if (!set.contains(e.getSyntax())) {
-						set.add(e.getSyntax());
-						other.append("\t\t\t<a href=\"" + e.kind() + e.getKeyword() + ".html" + "\" >" + e.getKeyword()
-								+ "</a><br />\n");
-					}
-					for (String k : e.options().keySet()) {
-						if (opSeen.contains(k)) {
-							continue;
-						}
-						opSeen.add(k);
-					}
-				}
-				other.append("<br/>Options:<br/></br>");
-				for (String x : opSeen) {
-					other.append("<a href=\"" + x + ".html\" >" + x + "</a><br/>\n");
-				}
+        String sss =
+            "<html><head>"
+                + css
+                + "</head><body><h1>"
+                + "example "
+                + ex.getName()
+                + "</h1><pre>\n"
+                + AqlInACan.strip(ex.getText().trim())
+                + "\n</pre> "
+                + other.toString()
+                + "\n<br/></br>"
+                + insts.toString()
+                + "</body></html>";
 
-				StringBuffer insts = new StringBuffer();
-				if (run) {
-					insts.append("\n");
-					try {
-						AqlMultiDriver dr = new AqlMultiDriver(prog, null);
-						dr.start();
-						for (String k : dr.env.defs.insts.keySet()) {
-							Instance<?, ?, ?, ?, ?, ?, ?, ?, ?> i = dr.env.defs.insts.get(k);
-							insts.append("<hr/>");
-							insts.append("<h3>instance " + k + "</h3>");
-							insts.append(AqlInACan.toHtml(dr.env,
-									(Instance<String, String, catdata.cql.exp.Sym, catdata.cql.exp.Fk, catdata.cql.exp.Att, String, String, Object, Object>) i));
-						}
-						for (String k : dr.env.defs.ps.keySet()) {
-							Pragma i = dr.env.defs.ps.get(k);
-							insts.append("<hr/>");
-							insts.append("<h3>command " + k + "</h3><pre>");
-							insts.append(i.toString());
-							insts.append("</pre>");
-						}
-					} catch (Exception exe) {
-						exe.printStackTrace();
-					}
-				}
+        Util.writeFile(sss, new File(dir, ex.getName() + ".html").getAbsolutePath());
+      }
+      examples.append("\n</body></html>");
 
-				String sss = "<html><head>" + css + "</head><body><h1>" + "example " + ex.getName() + "</h1><pre>\n"
-						+ AqlInACan.strip(ex.getText().trim()) + "\n</pre> " + other.toString() + "\n<br/></br>"
-						+ insts.toString() + "</body></html>";
+      StringBuffer logo = new StringBuffer("");
+      logo.append("<html><head>" + css + "</head><body>");
+      logo.append("\n<a href=\"syntax.html\" target=\"tree\">Syntax</a><br >");
+      logo.append("\n<a href=\"options.html\" target=\"tree\">Options</a><br >");
+      logo.append("\n<a href=\"examples.html\" target=\"tree\">Examples</a><br >");
 
-				Util.writeFile(sss, new File(dir, ex.getName() + ".html").getAbsolutePath());
-			}
-			examples.append("\n</body></html>");
+      logo.append("\n<br />");
+      // logo.append("\n<a href=\"http://categorical.info\" target=\"_blank\">CI
+      // Website</a><br />");
+      logo.append(
+          "\n<a href=\"http://categoricaldata.net\" target=\"_blank\">CQL Website</a><br >");
+      logo.append(
+          "\n<a href=\"http://github.com/CategoricalData/CQL/wiki\" target=\"_blank\">CQL Wiki</a><br >");
+      logo.append("\n</body></html>");
 
-			StringBuffer logo = new StringBuffer("");
-			logo.append("<html><head>" + css + "</head><body>");
-			logo.append("\n<a href=\"syntax.html\" target=\"tree\">Syntax</a><br >");
-			logo.append("\n<a href=\"options.html\" target=\"tree\">Options</a><br >");
-			logo.append("\n<a href=\"examples.html\" target=\"tree\">Examples</a><br >");
+      StringBuffer main = new StringBuffer();
+      main.append("<!DOCTYPE HTML>");
+      main.append("\n<HTML lang=\"en\">");
+      main.append("\n<HEAD>");
+      main.append("\n<TITLE>CQL</TITLE>");
+      main.append(css);
+      main.append("\n</HEAD>");
+      main.append("\n<FRAMESET cols=\"20%, 80%\">");
+      main.append("\n  <FRAMESET rows=\"100, 200\">");
+      main.append("\n      <FRAME src=\"logo.html\" name=\"logo\">");
+      main.append("\n      <FRAME src=\"syntax.html\" name=\"tree\">");
+      main.append("\n  </FRAMESET>");
+      main.append("\n  <FRAME src=\"\" name=\"primary\">");
+      main.append("\n</FRAMESET>");
+      main.append("\n</HTML>");
 
-			logo.append("\n<br />");
-			// logo.append("\n<a href=\"http://categorical.info\" target=\"_blank\">CI
-			// Website</a><br />");
-			logo.append("\n<a href=\"http://categoricaldata.net\" target=\"_blank\">CQL Website</a><br >");
-			logo.append(
-					"\n<a href=\"http://github.com/CategoricalData/CQL/wiki\" target=\"_blank\">CQL Wiki</a><br >");
-			logo.append("\n</body></html>");
+      StringBuffer syntax = new StringBuffer();
+      syntax.append("<html><head>" + css + "</head>\n\t");
+      Map<Kind, Set<Pair<AqlTyping, Exp<?>>>> z =
+          new TypingInversion().covisit(Unit.unit, x -> new AqlTyping());
+      Map<String, Set<Exp<?>>> opInv = Util.newSetsFor(AqlOptions.optionNames());
 
-			StringBuffer main = new StringBuffer();
-			main.append("<!DOCTYPE HTML>");
-			main.append("\n<HTML lang=\"en\">");
-			main.append("\n<HEAD>");
-			main.append("\n<TITLE>CQL</TITLE>");
-			main.append(css);
-			main.append("\n</HEAD>");
-			main.append("\n<FRAMESET cols=\"20%, 80%\">");
-			main.append("\n  <FRAMESET rows=\"100, 200\">");
-			main.append("\n      <FRAME src=\"logo.html\" name=\"logo\">");
-			main.append("\n      <FRAME src=\"syntax.html\" name=\"tree\">");
-			main.append("\n  </FRAMESET>");
-			main.append("\n  <FRAME src=\"\" name=\"primary\">");
-			main.append("\n</FRAMESET>");
-			main.append("\n</HTML>");
+      boolean isFirstK = true;
+      for (Kind k : Util.alphabetical(Arrays.asList(Kind.class.getEnumConstants()))) {
 
-			StringBuffer syntax = new StringBuffer();
-			syntax.append("<html><head>" + css + "</head>\n\t");
-			Map<Kind, Set<Pair<AqlTyping, Exp<?>>>> z = new TypingInversion().covisit(Unit.unit, x -> new AqlTyping());
-			Map<String, Set<Exp<?>>> opInv = Util.newSetsFor(AqlOptions.optionNames());
+        if (k.equals(Kind.COMMENT)) {
+          continue;
+        }
+        if (!isFirstK) {
+          syntax.append("<br/>");
+          isFirstK = false;
+        }
+        isFirstK = false;
+        syntax.append("<h3>" + k + "</h3>");
+        List<Pair<AqlTyping, Exp<?>>> ee = new ArrayList<>(z.get(k));
+        Collections.sort(ee, (x, y) -> x.second.getKeyword().compareTo(y.second.getKeyword()));
 
-			boolean isFirstK = true;
-			for (Kind k : Util.alphabetical(Arrays.asList(Kind.class.getEnumConstants()))) {
+        URL l = ClassLoader.getSystemResource("docs");
 
-				if (k.equals(Kind.COMMENT)) {
-					continue;
-				}
-				if (!isFirstK) {
-					syntax.append("<br/>");
-					isFirstK = false;
-				}
-				isFirstK = false;
-				syntax.append("<h3>" + k + "</h3>");
-				List<Pair<AqlTyping, Exp<?>>> ee = new ArrayList<>(z.get(k));
-				Collections.sort(ee, (x, y) -> x.second.getKeyword().compareTo(y.second.getKeyword()));
+        for (Pair<AqlTyping, Exp<?>> pair : ee) {
+          if (pair.second.isVar()) {
+            continue;
+          }
 
-				URL l = ClassLoader.getSystemResource("docs");
-				
-				for (Pair<AqlTyping, Exp<?>> pair : ee) {
-					if (pair.second.isVar()) {
-						continue;
-					}
+          AqlTyping g = pair.first;
+          Exp<?> e = pair.second;
 
-					AqlTyping g = pair.first;
-					Exp<?> e = pair.second;
+          //	String docFile = "docs/" + pair.second.getSyntax() + ".md";
+          String desc;
+          try {
+            URI uuu = ClassLoader.getSystemResource("docs").toURI();
+            String vvv = new File(uuu).getAbsolutePath() + "/" + pair.second.getSyntax() + ".md";
 
-				//	String docFile = "docs/" + pair.second.getSyntax() + ".md";
-					String desc;
-					try {
-						URI uuu = ClassLoader.getSystemResource("docs").toURI();
-						String vvv = new File(uuu).getAbsolutePath() + "/" + pair.second.getSyntax() + ".md";
-						
-				//		desc =  Util.readFile(new FileReader(new File(vvv)));
-						desc = Util.readFile(new FileReader(new File(vvv)));
-					} catch (java.lang.Exception fnfe) {
-						fnfe.printStackTrace();
-						//System.out.println("Missing doc: " + new File(vvv).getAbsolutePath());
-						desc = "TODO";
-					}
-					// Util.writeFile(desc, "docs/" + pair.second.getSyntax() + ".md");
+            //		desc =  Util.readFile(new FileReader(new File(vvv)));
+            desc = Util.readFile(new FileReader(new File(vvv)));
+          } catch (java.lang.Exception fnfe) {
+            fnfe.printStackTrace();
+            // System.out.println("Missing doc: " + new File(vvv).getAbsolutePath());
+            desc = "TODO";
+          }
+          // Util.writeFile(desc, "docs/" + pair.second.getSyntax() + ".md");
 
-					// String desc = e.accept0(Unit.unit, new AqlHelp());
+          // String desc = e.accept0(Unit.unit, new AqlHelp());
 
-					String str = e.printNicely(g).replace("<", "&lt;").replace(">", "&gt;");
-					String str2 = "<br/>Appears in:<br/><br/>";
+          String str = e.printNicely(g).replace("<", "&lt;").replace(">", "&gt;");
+          String str2 = "<br/>Appears in:<br/><br/>";
 
-					Set<AqlOption> xx = e.allowedOptions();
-					for (AqlOption op : xx) {
-						opInv.get(op.name()).add(e);
-					}
-					List<String> yy = xx.stream()
-							.map(x -> "<a href=\"" + x.name() + ".html\" target=\"primary\">" + x.name() + "</a>\n")
-							.collect(Collectors.toList());
-					String str3 = "Options:<br/><br/>" + Util.sep(Util.alphabetical(yy), "<br/>\n");
+          Set<AqlOption> xx = e.allowedOptions();
+          for (AqlOption op : xx) {
+            opInv.get(op.name()).add(e);
+          }
+          List<String> yy =
+              xx.stream()
+                  .map(
+                      x ->
+                          "<a href=\""
+                              + x.name()
+                              + ".html\" target=\"primary\">"
+                              + x.name()
+                              + "</a>\n")
+                  .collect(Collectors.toList());
+          String str3 = "Options:<br/><br/>" + Util.sep(Util.alphabetical(yy), "<br/>\n");
 
-					for (Example ex : Util.alphabetical(Examples.getExamples(Language.CQL))) {
-						if (!index.containsKey(ex)) {
-							continue;
-						}
-						if (index.get(ex).contains(e.getSyntax())) {
-							str2 += "\n<a href=\"" + ex.getName().trim() + ".html\" target=\"primary\">"
-									+ ex.getName().trim() + "</a><br />";
-						}
-					}
+          for (Example ex : Util.alphabetical(Examples.getExamples(Language.CQL))) {
+            if (!index.containsKey(ex)) {
+              continue;
+            }
+            if (index.get(ex).contains(e.getSyntax())) {
+              str2 +=
+                  "\n<a href=\""
+                      + ex.getName().trim()
+                      + ".html\" target=\"primary\">"
+                      + ex.getName().trim()
+                      + "</a><br />";
+            }
+          }
 
-					String dstFile = new File(dir, e.kind() + e.getKeyword() + ".html").getAbsolutePath();
-					Util.writeFile(
-							"<html><head>" + css + "</head><h1>" + e.kind() + " " + e.getKeyword() + "</h1>\n<pre>\n"
-									+ str + "\n\t</pre>\n" + desc + "<br/>" + str2 + "<br/>" + str3 + "</html>",
-							dstFile);
-					syntax.append("<a href=\"" + e.kind() + e.getKeyword() + ".html" + "\" target=\"primary\">"
-							+ e.getKeyword() + "</a><br />\n");
+          String dstFile = new File(dir, e.kind() + e.getKeyword() + ".html").getAbsolutePath();
+          Util.writeFile(
+              "<html><head>"
+                  + css
+                  + "</head><h1>"
+                  + e.kind()
+                  + " "
+                  + e.getKeyword()
+                  + "</h1>\n<pre>\n"
+                  + str
+                  + "\n\t</pre>\n"
+                  + desc
+                  + "<br/>"
+                  + str2
+                  + "<br/>"
+                  + str3
+                  + "</html>",
+              dstFile);
+          syntax.append(
+              "<a href=\""
+                  + e.kind()
+                  + e.getKeyword()
+                  + ".html"
+                  + "\" target=\"primary\">"
+                  + e.getKeyword()
+                  + "</a><br />\n");
+        }
+        //        syntax.append("\t<br");
+      }
+      syntax.append("</html>\n");
 
-				}
-//        syntax.append("\t<br");
-			}
-			syntax.append("</html>\n");
+      StringBuffer options = new StringBuffer("<html><head>" + css + "</head><body>");
+      for (AqlOption ex : Util.alphabetical(Arrays.asList(AqlOption.class.getEnumConstants()))) {
 
-			StringBuffer options = new StringBuffer("<html><head>" + css + "</head><body>");
-			for (AqlOption ex : Util.alphabetical(Arrays.asList(AqlOption.class.getEnumConstants()))) {
+        options.append(
+            "\n<a href=\"" + ex.name() + ".html\" target=\"primary\">" + ex.name() + "</a><br />");
+        StringBuffer zzz = new StringBuffer();
+        Set<AqlSyntax> seen = new THashSet<>();
+        for (Exp<?> e : opInv.get(ex.toString())) {
+          AqlSyntax f = e.getSyntax();
+          if (seen.contains(f)) {
+            continue;
+          }
+          seen.add(f);
+          zzz.append(
+              "\t\t\t<a href=\""
+                  + e.kind()
+                  + e.getKeyword()
+                  + ".html"
+                  + "\" target=\"primary\">"
+                  + e.getKeyword()
+                  + "</a><br />\n");
+        }
+        StringBuffer yyy = new StringBuffer();
+        for (Example example : Util.alphabetical(Examples.getExamples(Language.CQL))) {
 
-				options.append("\n<a href=\"" + ex.name() + ".html\" target=\"primary\">" + ex.name() + "</a><br />");
-				StringBuffer zzz = new StringBuffer();
-				Set<AqlSyntax> seen = new THashSet<>();
-				for (Exp<?> e : opInv.get(ex.toString())) {
-					AqlSyntax f = e.getSyntax();
-					if (seen.contains(f)) {
-						continue;
-					}
-					seen.add(f);
-					zzz.append("\t\t\t<a href=\"" + e.kind() + e.getKeyword() + ".html" + "\" target=\"primary\">"
-							+ e.getKeyword() + "</a><br />\n");
-				}
-				StringBuffer yyy = new StringBuffer();
-				for (Example example : Util.alphabetical(Examples.getExamples(Language.CQL))) {
+          if (example.getText().contains(ex.toString())) {
+            yyy.append(
+                "\n<a href=\""
+                    + example.getName().trim()
+                    + ".html\" target=\"primary\">"
+                    + example.getName()
+                    + "</a><br />");
+          }
+        }
 
-					if (example.getText().contains(ex.toString())) {
-						yyy.append("\n<a href=\"" + example.getName().trim() + ".html\" target=\"primary\">"
-								+ example.getName() + "</a><br />");
-					}
-				}
+        String sss =
+            "<html><head>"
+                + css
+                + "</head><body><h1>"
+                + "option "
+                + ex.name()
+                + "</h1>\n"
+                + AqlHelp.getOptionText(ex)
+                + "<br/><br/>Keyword:</br><br/>"
+                + zzz
+                + "<br/>Appears in:</br><br/>"
+                + yyy
+                + "</body></html>";
+        Util.writeFile(sss, new File(dir, ex.name() + ".html").getAbsolutePath());
+      }
+      options.append("\n</body></html>");
 
-				String sss = "<html><head>" + css + "</head><body><h1>" + "option " + ex.name() + "</h1>\n"
-						+ AqlHelp.getOptionText(ex) + "<br/><br/>Keyword:</br><br/>" + zzz
-						+ "<br/>Appears in:</br><br/>" + yyy + "</body></html>";
-				Util.writeFile(sss, new File(dir, ex.name() + ".html").getAbsolutePath());
-			}
-			options.append("\n</body></html>");
+      Util.writeFile(options.toString(), new File(dir, "options.html").getAbsolutePath());
+      Util.writeFile(examples.toString(), new File(dir, "examples.html").getAbsolutePath());
+      Util.writeFile(main.toString(), new File(dir, "index.html").getAbsolutePath());
+      Util.writeFile(syntax.toString(), new File(dir, "syntax.html").getAbsolutePath());
+      Util.writeFile(logo.toString(), new File(dir, "logo.html").getAbsolutePath());
 
-			Util.writeFile(options.toString(), new File(dir, "options.html").getAbsolutePath());
-			Util.writeFile(examples.toString(), new File(dir, "examples.html").getAbsolutePath());
-			Util.writeFile(main.toString(), new File(dir, "index.html").getAbsolutePath());
-			Util.writeFile(syntax.toString(), new File(dir, "syntax.html").getAbsolutePath());
-			Util.writeFile(logo.toString(), new File(dir, "logo.html").getAbsolutePath());
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      throw new RuntimeException(ex);
+    }
+  }
 
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			throw new RuntimeException(ex);
-		}
+  public String report() {
 
-	}
+    Map<Kind, Set<Pair<AqlTyping, Exp<?>>>> exps =
+        new TypingInversion().covisit(Unit.unit, x -> new AqlTyping());
 
-	public String report() {
+    StringBuffer sb = new StringBuffer();
 
-		Map<Kind, Set<Pair<AqlTyping, Exp<?>>>> exps = new TypingInversion().covisit(Unit.unit, x -> new AqlTyping());
-
-		StringBuffer sb = new StringBuffer();
-
-		for (Kind k : Kind.class.getEnumConstants()) {
-			for (Pair<AqlTyping, Exp<?>> pair : exps.get(k)) {
-				AqlTyping g = pair.first;
-				Exp<?> e = pair.second;
-				if (e == null) {
-					continue;
-				}
-				sb.append(e.printNicely(g));
-				sb.append("\n\n");
-			}
-		}
-		return sb.toString();
-	}
-
+    for (Kind k : Kind.class.getEnumConstants()) {
+      for (Pair<AqlTyping, Exp<?>> pair : exps.get(k)) {
+        AqlTyping g = pair.first;
+        Exp<?> e = pair.second;
+        if (e == null) {
+          continue;
+        }
+        sb.append(e.printNicely(g));
+        sb.append("\n\n");
+      }
+    }
+    return sb.toString();
+  }
 }

--- a/src/catdata/cql/exp/TypingInversion.java
+++ b/src/catdata/cql/exp/TypingInversion.java
@@ -1,9 +1,5 @@
 package catdata.cql.exp;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
 import catdata.LocStr;
 import catdata.Pair;
 import catdata.Unit;
@@ -67,2494 +63,2653 @@ import catdata.cql.exp.TyExp.TyExpLit;
 import catdata.cql.exp.TyExp.TyExpVar;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class TypingInversion implements ExpCoVisitor<AqlTyping, Unit, RuntimeException> {
 
-	@Override
-	public TyExpSch visitTyExpSch(Unit params, AqlTyping exp) {
-		SchExpVar e = new SchExpVar("s");
-		TyExpVar x = new TyExpVar("t");
-		TyExpSch t = new TyExpSch(e);
-		exp.defs.schs.put("s", x);
-		exp.defs.tys.put("t", Unit.unit);
-		return t;
-	}
-
-	@Override
-	public TyExpEmpty visitTyExpEmpty(Unit params, AqlTyping exp) {
-		return new TyExpEmpty();
-	}
-
-	@Override
-	public TyExpLit visitTyExpLit(Unit params, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public TyExpVar visitTyExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar e = new TyExpVar("t");
-		return e;
-	}
-
-	@Override
-	public TyExpRaw visitTyExpRaw(Unit params, AqlTyping exp) {
-		return new TyExpRaw(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList());
-	}
-
-	@Override
-	public TyExpSql visitTyExpSql(Unit params, AqlTyping exp) {
-		return new TyExpSql();
-	}
-
-	@Override
-	public TyExpRdf visitTyExpRdf(Unit params, AqlTyping exp) {
-		return new TyExpRdf();
-	}
-
-	@Override
-	public SchExpCod visitSchExpCod(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new SchExpCod(new QueryExpVar("q"));
-	}
-
-	@Override
-	public SchExpDom visitSchExpDom(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new SchExpDom(new QueryExpVar("q"));
-	}
-
-	@Override
-	public SchExpDst visitSchExpDst(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new SchExpDst(new MapExpVar("m"));
-	}
-
-	@Override
-	public SchExpSrc visitSchExpSrc(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new SchExpSrc(new MapExpVar("m"));
-	}
-
-	@Override
-	public SchExpEmpty visitSchExpEmpty(Unit params, AqlTyping exp) {
-		TyExp t = new TyExpVar("t");
-		exp.defs.tys.put("t", Unit.unit);
-		return new SchExpEmpty(t);
-	}
-
-	@Override
-	public SchExpInst visitSchExpInst(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		exp.prog.exps.put("i", i);
-		return new SchExpInst(i);
-
-	}
-
-	@Override
-	public SchExpLit visitSchExpLit(Unit params, AqlTyping exp) {
-		return null;
-//    return new SchExpLit(Schema.terminal(TypeSide.initial()));
-	}
-
-	@Override
-	public SchExpPivot visitSchExpPivot(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp x = new TyExpVar("t");
-		InstExp q = new InstExpVar("i");
-		exp.defs.schs.put("s", x);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new SchExpPivot(q, new LinkedList());
-	}
-
-	@Override
-	public SchExpVar visitSchExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar e = new TyExpVar("t");
-		exp.defs.schs.put("s", e);
-		return new SchExpVar("s");
-	}
-
-	@Override
-	public SchExpRaw visitSchExpRaw(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar e = new TyExpVar("t");
-		return new SchExpRaw(e, new LinkedList(), new LinkedList(), new LinkedList(), new LinkedList(),
-				new LinkedList(), new LinkedList(), new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public SchExpColim visitSchExpColim(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		ColimSchExp x = new ColimSchExpVar("sc");
-		exp.defs.scs.put("sc", new THashSet());
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		exp.prog.exps.put("sc", q);
-		return new SchExpColim(x);
-
-	}
-
-	@Override
-	public MapExpComp visitMapExpComp(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.schs.put("s3", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-		SchExpVar s3 = new SchExpVar("s3");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("s3", new SchExpEmpty(t));
-
-		MapExpVar m12 = new MapExpVar("m12");
-		MapExpVar m23 = new MapExpVar("m23");
-
-		exp.defs.maps.put("m12", new Pair(s1, s2));
-		exp.defs.maps.put("m23", new Pair(s2, s3));
-
-		return new MapExpComp(m12, m23);
-	}
-
-	@Override
-	public MapExpId visitMapExpId(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-
-		exp.defs.schs.put("s", t);
-		SchExpVar s = new SchExpVar("s");
-
-		return new MapExpId(s);
-	}
-
-	@Override
-	public QueryExpVar visitQueryExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new QueryExpVar("q");
-	}
-
-	@Override
-	public QueryExpRaw visitQueryExpRaw(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		// exp.defs.qs.put("q", new Pair(s1, s2));
-		return new QueryExpRaw(Collections.emptyList(), Collections.emptyList(), s1, s2, Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> MapExpPivot<Gen, Sk, X, Y> visitMapExpPivot(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp x = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", x);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-//    String l = new SchExpPivot(q, new LinkedList());
-		return new MapExpPivot(i, new LinkedList());
-	}
-
-	@Override
-	public MapExpVar visitMapExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new MapExpVar("m");
-	}
-
-	@Override
-	public MapExpRaw visitMapExpRaw(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-//    exp.defs.maps.put("m", new Pair(s1, s2));
-		return new MapExpRaw(s1, s2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public MapExpColim visitMapExpColim(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.scs.put("sc", new THashSet());
-		exp.defs.schs.put("s", t);
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.singletonList(new LocStr(0, "s")),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		exp.prog.exps.put("sc", q);
-		return new MapExpColim("s", q);
-	}
-
-	@Override
-	public QueryExpCompose visitQueryExpCompose(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.schs.put("s3", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-		SchExpVar s3 = new SchExpVar("s3");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("s3", new SchExpEmpty(t));
-
-		QueryExpVar m12 = new QueryExpVar("q12");
-		QueryExpVar m23 = new QueryExpVar("q23");
-
-		exp.defs.qs.put("q12", new Pair(s1, s2));
-		exp.defs.qs.put("q23", new Pair(s2, s3));
-
-		return new QueryExpCompose(m12, m23, Collections.emptyList());
-	}
-
-	@Override
-	public QueryExpId visitQueryExpId(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-
-		exp.defs.schs.put("s", t);
-		SchExpVar s = new SchExpVar("s");
-
-		return new QueryExpId(s);
-	}
-
-	@Override
-	public QueryExpLit visitQueryExpLit(Unit params, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public QueryExpDeltaCoEval visitQueryExpDeltaCoEval(Unit params, AqlTyping exp) {
-
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-
-		MapExp m = new MapExpVar("m");
-
-		exp.defs.maps.put("m", new Pair(s1, s2));
-
-		return new QueryExpDeltaCoEval(m, Collections.emptyList());
-	}
-
-	@Override
-	public QueryExpDeltaEval visitQueryExpDeltaEval(Unit params, AqlTyping exp) {
-
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-
-		MapExpVar m = new MapExpVar("m");
-
-		exp.defs.maps.put("m", new Pair(s1, s2));
-
-		return new QueryExpDeltaEval(m, Collections.emptyList());
-
-	}
-
-	@Override
-	public QueryExpRawSimple visitQueryExpRawSimple(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s", t);
-		SchExp s1 = new SchExpVar("s");
-		return new QueryExpRawSimple(s1);
-	}
-
-	@Override
-	public EdsExpVar visitEdsExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		SchExpVar s = new SchExpVar("s");
-
-		exp.defs.schs.put("s", t);
-		exp.defs.eds.put("c", s);
-
-		return new EdsExpVar("c");
-	}
-
-	@Override
-	public EdsExpRaw visitEdsExpRaw(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		SchExpVar s = new SchExpVar("s");
-		exp.defs.schs.put("s", t);
-
-		return new EdsExpRaw(s, Collections.emptyList(), Collections.emptyList(), Unit.unit);
-	}
-
-	@Override
-	public GraphExpRaw visitGraphExpRaw(Unit params, AqlTyping exp) {
-		return new GraphExpRaw(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public GraphExpVar visitGraphExpVar(Unit params, AqlTyping exp) {
-		exp.defs.gs.put("g", Unit.unit);
-		return new GraphExpVar("g");
-	}
-
-	@Override
-	public GraphExpLiteral visitGraphExpLiteral(Unit params, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public <X, Y> PragmaExpConsistent<X, Y> visitPragmaExpConsistent(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpConsistent(i);
-	}
-
-	@Override
-	public <X, Y> PragmaExpCheck<X, Y> visitPragmaExpCheck(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		EdsExp c = new EdsExpVar("c");
-		exp.defs.eds.put("c", s);
-		return new PragmaExpCheck(i, c, Collections.emptyList());
-	}
-
-	@Override
-	public PragmaExpMatch visitPragmaExpMatch(Unit params, AqlTyping exp) {
-		exp.defs.gs.put("g1", Unit.unit);
-		exp.defs.gs.put("g2", Unit.unit);
-		GraphExp g1 = new GraphExpVar("g1");
-		GraphExp g2 = new GraphExpVar("g2");
-		return new PragmaExpMatch("method", g1, g2, Collections.emptyList());
-	}
-
-	@Override
-	public PragmaExpSql visitPragmaExpSql(Unit params, AqlTyping exp) {
-		return new PragmaExpSql("jdbc_string", Collections.emptyList(), new LinkedList());
-	}
-
-	@Override
-	public <X, Y> PragmaExpToCsvInst<X, Y> visitPragmaExpToCsvInst(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpToCsvInst(i, "directory", new LinkedList());
-	}
-
-	@Override
-	public PragmaExpVar visitPragmaExpVar(Unit params, AqlTyping exp) {
-		exp.defs.ps.put("p", Unit.unit);
-		PragmaExpVar e = new PragmaExpVar("p");
-		return e;
-	}
-
-	@Override
-	public PragmaExpJs visitPragmaExpJs(Unit params, AqlTyping exp) {
-		return new PragmaExpJs(Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public PragmaExpProc visitPragmaExpProc(Unit params, AqlTyping exp) {
-		return new PragmaExpProc(Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public <X, Y> PragmaExpToJdbcInst<X, Y> visitPragmaExpToJdbcInst(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpToJdbcInst(i, "jdbc_string", "prefix", new LinkedList());
-
-	}
-
-	@Override
-	public <Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> PragmaExpToJdbcTrans<Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> visitPragmaExpToJdbcTrans(
-			Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<Object, Object, Object, Object> i1 = new InstExpVar("i1");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		InstExp<Object, Object, Object, Object> i2 = new InstExpVar("i2");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		return new PragmaExpToJdbcTrans(h, "jdbc_string", "prefix", new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public PragmaExpToJdbcQuery visitPragmaExpToJdbcQuery(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		QueryExpVar q = new QueryExpVar("q");
-		return new PragmaExpToJdbcQuery(q, "jdbc_string", "prefix_src", "prefix_dst", new LinkedList());
-	}
-
-	@Override
-	public <Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> PragmaExpToCsvTrans<Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> visitPragmaExpToCsvTrans(
-			Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<Object, Object, Object, Object> i1 = new InstExpVar("i1");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		InstExp<Object, Object, Object, Object> i2 = new InstExpVar("i2");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		return new PragmaExpToCsvTrans(h, "directory", new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public PragmaExpCheck2 visitPragmaExpCheck2(Unit params, AqlTyping exp) {
-		TyExpVar t = new TyExpVar("t");
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		QueryExp q = new QueryExpVar("q");
-
-		exp.defs.eds.put("c1", s1);
-		exp.defs.eds.put("c2", s2);
-
-		EdsExp c1 = new EdsExpVar("c1");
-		EdsExp c2 = new EdsExpVar("c2");
-
-		return new PragmaExpCheck2(q, c1, c2);
-	}
-
-	@Override
-	public ColimSchExpQuotient visitColimSchExpQuotient(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		return q;
-	}
-
-	@Override
-	public ColimSchExpRaw visitColimSchExpRaw(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.defs.gs.put("g", Unit.unit);
-		GraphExp g = new GraphExpVar("g");
-		return new ColimSchExpRaw(g, t, new LinkedList(), new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public ColimSchExpVar visitColimSchExpVar(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		ColimSchExpVar x = new ColimSchExpVar("sc");
-		exp.defs.scs.put("sc", new THashSet());
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		exp.prog.exps.put("sc", q);
-		return x;
-	}
-
-	@Override
-	public ColimSchExpWrap visitColimSchExpWrap(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		ColimSchExpVar x = new ColimSchExpVar("sc");
-		exp.defs.scs.put("sc", new THashSet());
-		SchExp s = new SchExpVar("s");
-		SchExp ss = new SchExpColim(x);
-
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		exp.prog.exps.put("sc", q);
-
-		MapExp m1 = new MapExpVar("m1");
-		MapExp m2 = new MapExpVar("m2");
-		exp.defs.maps.put("m1", new Pair(ss, s));
-		exp.defs.maps.put("m2", new Pair(s, ss));
-
-		return new ColimSchExpWrap(x, m1, m2);
-	}
-
-	@Override
-	public ColimSchExpModify visitColimSchExpModify(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		ColimSchExpVar x = new ColimSchExpVar("sc");
-		exp.defs.scs.put("sc", new THashSet());
-
-		ColimSchExpQuotient q = new ColimSchExpQuotient(t, Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-		exp.prog.exps.put("sc", q);
-
-		return new ColimSchExpModify(x, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpSigma<Gen, Sk, X, Y> visitInstExpSigma(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.insts.put("i", s1);
-		MapExpVar m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new InstExpSigma(m, i, Collections.emptyMap());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpSigmaChase<Gen, Sk, X, Y> visitInstExpSigmaChase(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.defs.insts.put("i", s1);
-		MapExpVar m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new InstExpSigmaChase(m, i, Collections.emptyMap());
-	}
-
-	@Override
-	public InstExpVar visitInstExpVar(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExpVar i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return i;
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpAnonymize<Gen, Sk, X, Y> visitInstExpAnonymize(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<Object, Object, Object, Object> i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new InstExpAnonymize(i);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpChase<Gen, Sk, X, Y> visitInstExpChase(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		exp.defs.eds.put("c", s);
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		EdsExpVar c = new EdsExpVar("c");
-		return new InstExpChase(c, i, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> InstExpCoEq<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpCoEq(
-			Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		TransExpVar h1 = new TransExpVar("h1");
-		exp.defs.trans.put("h1", new Pair(i1, i2));
-		TransExpVar h2 = new TransExpVar("h2");
-		exp.defs.trans.put("h2", new Pair(i1, i2));
-
-		return new InstExpCoEq(h1, h2, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpColim<Gen, Sk, X, Y> visitInstExpColim(Unit param, AqlTyping exp) {
-		GraphExpVar g = new GraphExpVar("g");
-		SchExp s = new SchExpVar("s");
-		exp.defs.tys.put("t", Unit.unit);
-		return new InstExpColim(g, s, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpCoProdFull<Gen, Sk, X, Y> visitInstExpCoProdFull(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		List<String> l = new LinkedList();
-		l.add("i1");
-		l.add("i2");
-		return new InstExpCoProdFull(l, s, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y, Gen1, Sk1, X1> InstExpDiff<Gen, Sk, X, Y, Gen1, Sk1, X1> visitInstExpDiff(Unit param,
-			AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		return new InstExpDiff(i1, i2);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpDistinct<Gen, Sk, X, Y> visitInstExpDistinct(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new InstExpDistinct(i);
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> InstExpDom<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpDom(
-			Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		TransExpVar h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		return new InstExpDom(h);
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> InstExpCod<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpCod(
-			Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		TransExpVar h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		return new InstExpCod(h);
-	}
-
-	@Override
-	public InstExpEmpty visitInstExpEmpty(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		return new InstExpEmpty(s);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpEval<Gen, Sk, X, Y> visitInstExpEval(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		QueryExpVar q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new InstExpEval(q, i, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpCoEval<Gen, Sk, X, Y> visitInstExpCoEval(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.insts.put("i", s2);
-		QueryExpVar q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new InstExpCoEval(q, i, Collections.emptyList());
-	}
-
-	@Override
-	public InstExpFrozen visitInstExpFrozen(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		QueryExpVar q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new InstExpFrozen(q, "an_entity_or_type");
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpLit<Gen, Sk, X, Y> visitInstExpLit(Unit param, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpPivot<Gen, Sk, X, Y> visitInstExpPivot(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new InstExpPivot(i, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpPi<Gen, Sk, X, Y> visitInstExpPi(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		MapExpVar m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		return new InstExpPi(m, i, Collections.emptyMap());
-	}
-
-	@Override
-	public InstExpCsv visitInstExpCsv(Unit param, AqlTyping exp) {
-		TyExp t = new TyExpSql();
-		return new InstExpCsv(t, new LinkedList(), new LinkedList(), "directory");
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpDelta<Gen, Sk, X, Y> visitInstExpDelta(Unit param, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		MapExpVar m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s2, s1));
-		return new InstExpDelta(m, i);
-	}
-
-	@Override
-	public InstExpJdbc visitInstExpJdbc(Unit param, AqlTyping exp) {
-		TyExp t = new TyExpSql();
-		return new InstExpJdbc(t, new LinkedList(), "jdbc_string", new LinkedList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpQueryQuotient<Gen, Sk, X, Y> visitInstExpQueryQuotient(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new InstExpQueryQuotient(i, Collections.emptyList(), Collections.emptyList());
-
-	}
-
-	@Override
-	public InstExpRandom visitInstExpRandom(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		return new InstExpRandom(s, new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public InstExpRaw visitInstExpRaw(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		return new InstExpRaw(s, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpEval<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpEval(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpEval(q, h, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpCoEval<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpCoEval(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s2, s1));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpCoEval(q, h, new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpCoEvalEvalCoUnit<Gen, Sk, X, Y> visitTransExpCoEvalEvalCoUnit(Unit params,
-			AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		InstExp i = new InstExpVar("i");
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-
-		return new TransExpCoEvalEvalCoUnit(q, i, new THashMap());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpCoEvalEvalUnit<Gen, Sk, X, Y> visitTransExpCoEvalEvalUnit(Unit params,
-			AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s2, s1));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		InstExp i = new InstExpVar("i");
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-
-		return new TransExpCoEvalEvalUnit(q, i, new THashMap());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpSigmaDeltaCounit<Gen, Sk, X, Y> visitTransExpSigmaDeltaCounit(Unit params,
-			AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		MapExp m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		InstExp i = new InstExpVar("i");
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-
-		return new TransExpSigmaDeltaCounit(m, i, new THashMap());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpSigmaDeltaUnit<Gen, Sk, X, Y> visitTransExpSigmaDeltaUnit(Unit params,
-			AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		MapExp m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s2, s1));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		InstExp i = new InstExpVar("i");
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-
-		return new TransExpSigmaDeltaUnit(m, i, new THashMap());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2, Gen3, Sk3, X3, Y3> TransExpCompose<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2, Gen3, Sk3, X3, Y3> visitTransExpCompose(
-			Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s", t);
-		SchExpVar s = new SchExpVar("s");
-
-		InstExpVar i1 = new InstExpVar("i1");
-		InstExpVar i2 = new InstExpVar("i2");
-		InstExpVar i3 = new InstExpVar("i3");
-
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		exp.defs.insts.put("i3", s);
-
-		exp.prog.exps.put("i1", new InstExpEmpty(s));
-		exp.prog.exps.put("i2", new InstExpEmpty(s));
-		exp.prog.exps.put("i3", new InstExpEmpty(s));
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-
-		TransExpVar h12 = new TransExpVar("h12");
-		TransExpVar h23 = new TransExpVar("h23");
-
-		exp.defs.trans.put("h12", new Pair(i1, i2));
-		exp.defs.trans.put("h23", new Pair(i2, i3));
-
-		return new TransExpCompose(h12, h23);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpId<Gen, Sk, X, Y> visitTransExpId(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.insts.put("i", s);
-		return new TransExpId(i);
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpDelta<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpDelta(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		MapExp m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s2, s1));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpDelta(m, h);
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpSigma<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpSigma(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		MapExp m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpSigma(m, h, new THashMap(), new THashMap());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpPi<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpPi(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		MapExp m = new MapExpVar("m");
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpPi(m, h, new THashMap(), new THashMap());
-	}
-
-	@Override
-	public TransExpRaw visitTransExpRaw(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		return new TransExpRaw(i1, i2, new LinkedList(), new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public TransExpVar visitTransExpVar(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		TransExpVar h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		return h;
-
-	}
-
-	@Override
-	public <X1, Y1, X2, Y2> TransExpCsv<X1, Y1, X2, Y2> visitTransExpCsv(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		return new TransExpCsv(i1, i2, new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public <X1, Y1, X2, Y2> TransExpJdbc<X1, Y1, X2, Y2> visitTransExpJdbc(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		return new TransExpJdbc("jdbc_string", i1, i2, new LinkedList(), new LinkedList());
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpDistinct<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpDistinct(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		InstExp j = new InstExpVar("j");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.defs.insts.put("j", s1);
-		InstExp i = new InstExpVar("i");
-		TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i, j));
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-		exp.prog.exps.put("j", new InstExpEmpty(s2));
-
-		return new TransExpDistinct(h);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpDistinct2<Gen, Sk, X, Y> visitTransExpDistinct2(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("i", new InstExpEmpty(s1));
-
-		return new TransExpDistinct2(i);
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpLit<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpLit(
-			Unit params, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public MapExpLit visitMapExpLit(Unit params, AqlTyping exp) {
-		return null;
-	}
-
-	@Override
-	public CommentExp visitCommentExp(Unit params, AqlTyping exp) {
-		return new CommentExp("hello world", false);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> TransExpDiffReturn<Gen, Sk, X, Y> visitTransExpDiffReturn(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		return new TransExpDiffReturn(i1, i2);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y, Gen1, Gen2, Sk1, Sk2, X1, X2> TransExpDiff<Gen, Sk, X, Y, Gen1, Gen2, Sk1, Sk2, X1, X2> visitTransExpDiff(
-			Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		InstExp i1 = new InstExpVar("i1");
-		InstExp i2 = new InstExpVar("i2");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		exp.defs.insts.put("i1", s);
-		exp.defs.insts.put("i2", s);
-		TransExp h = new TransExpVar("h");
-		exp.defs.trans.put("h", new Pair(i1, i2));
-		return new TransExpDiff(i, h);
-	}
-
-	@Override
-	public TransExpFrozen visitTransExpFrozen(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		QueryExpVar q = new QueryExpVar("q");
-		exp.defs.qs.put("q", new Pair(s1, s2));
-		return new TransExpFrozen(q, "var", "entity", new RawTerm("term", Collections.emptyList()), "entity_or_type");
-	}
-
-	@Override
-	public QueryExpFromCoSpan visitQueryExpFromCoSpan(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.schs.put("s3", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-		SchExpVar s3 = new SchExpVar("s3");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("s3", new SchExpEmpty(t));
-
-		MapExpVar m12 = new MapExpVar("m12");
-		MapExpVar m32 = new MapExpVar("m32");
-
-		exp.defs.maps.put("m12", new Pair(s1, s2));
-		exp.defs.maps.put("m32", new Pair(s3, s2));
-
-		return new QueryExpFromCoSpan(m12, m32, Collections.emptyList());
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpCascadeDelete<Gen, Sk, X, Y> visitInstExpCascadeDelete(Unit param, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		// exp.defs.schs.put("s2", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-//    SchExpVar s2 = new SchExpVar("s2");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-//    exp.prog.exps.put("s2", new SchExpEmpty(t));
-
-		InstExp i = new InstExpVar("i");
-		exp.defs.insts.put("i", s1);
-
-		return new InstExpCascadeDelete(i, s1);
-	}
-
-	@Override
-	public SchExpJdbcAll visitSchExpJdbcAll(Unit params, AqlTyping r) {
-		return new SchExpJdbcAll("jdbc_string", new LinkedList());
-	}
-
-	@Override
-	public QueryExpFromEds visitQueryExpFromEds(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.defs.schs.put("s", t);
-		exp.defs.eds.put("eds", new SchExpVar("s")); // , Collections.emptyList(), Collections.emptyList(), Unit.unit));
-		EdsExpVar eds = new EdsExpVar("eds");
-
-		return new QueryExpFromEds(eds, 0);
-	}
-
-	@Override
-	public EdsExpSch visitEdsExpSch(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.defs.schs.put("s", t);
-		SchExpVar s = new SchExpVar("s");
-		exp.prog.exps.put("s", new SchExpEmpty(t));
-
-		return new EdsExpSch(s);
-	}
-
-	@Override
-	public TyExp visitTyExpAdt(Unit params, AqlTyping r) {
-		return new TyExpAdt(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList());
-	}
-
-	@Override
-	public ApgTyExpVar visitApgTyExpVar(Unit params, AqlTyping r) {
-		r.defs.apgts.put("t", Unit.unit);
-		ApgTyExpVar e = new ApgTyExpVar("t");
-		return e;
-	}
-
-	@Override
-	public ApgTyExpRaw visitApgTyExpRaw(Unit params, AqlTyping r) {
-		return new ApgTyExpRaw(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public ApgInstExpInitial visitApgInstExpInitial(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		return new ApgInstExpInitial(s);
-	}
-
-	@Override
-	public ApgInstExpTerminal visitApgInstExpTerminal(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		return new ApgInstExpTerminal(t);
-	}
-
-	@Override
-	public ApgInstExpTimes visitApgInstExpTimes(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		ApgInstExpVar a = new ApgInstExpVar("G1");
-		ApgInstExpVar b = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G1", s);
-		r.defs.apgis.put("G2", s);
-		return new ApgInstExpTimes(a, b);
-	}
-
-	@Override
-	public ApgInstExpPlus visitApgInstExpPlus(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		ApgInstExpVar a = new ApgInstExpVar("G1");
-		ApgInstExpVar b = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G1", s);
-		r.defs.apgis.put("G2", s);
-		return new ApgInstExpPlus(a, b);
-	}
-
-	@Override
-	public ApgInstExpVar visitApgInstExpVar(Unit param, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		ApgInstExpVar a = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-		return a;
-	}
-
-	@Override
-	public ApgInstExpRaw visitApgInstExpRaw(Unit param, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		ApgInstExpRaw a = new ApgInstExpRaw(s, Collections.emptyList(), Collections.emptyList());
-		r.defs.apgis.put("G", s);
-		return a;
-	}
-
-	@Override
-	public ApgTransExpRaw visitApgTransExpRaw(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		return new ApgTransExpRaw(G1, G2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public ApgTransExpVar visitApgTransExpVar(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		r.defs.apgis.put("G1", s1);
-		r.defs.apgis.put("G2", s2);
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		return new ApgTransExpVar("h");
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpInitial(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		r.defs.apgms.put("h", new Pair<>(new ApgInstExpInitial(s), G));
-		return new ApgTransExpVar("h");
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpTerminal(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		r.defs.apgms.put("h", new Pair<>(G, new ApgInstExpTerminal(t)));
-		return new ApgTransExpVar("h");
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpFst(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		return new ApgTransExpFst(G1, G2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpSnd(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		return new ApgTransExpSnd(G1, G2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpInl(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		return new ApgTransExpInl(G1, G2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpInr(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		return new ApgTransExpInr(G1, G2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpId(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		return new ApgTransExpId(G1);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpCase(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-		ApgSchExp s3 = new ApgSchExpVar("s3");
-		r.defs.apgschemas.put("s3", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s3);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G));
-		r.defs.apgms.put("h'", new Pair<>(G2, G));
-
-		return new ApgTransExpCase(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpPair(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G, G1));
-		r.defs.apgms.put("h'", new Pair<>(G, G2));
-
-		return new ApgTransExpPair(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpCompose(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s3 = new ApgSchExpVar("s3");
-		r.defs.apgschemas.put("s3", t);
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-		ApgInstExp G3 = new ApgInstExpVar("G3");
-		r.defs.apgis.put("G3", s3);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G2, G3));
-
-		return new ApgTransExpCompose(h1, h2);
-	}
-
-	@Override
-	public ApgInstExpEqualize visitApgInstExpEqualize(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-
-		return new ApgInstExpEqualize(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpEqualize(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-
-		return new ApgTransExpEqualize(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpEqualizeU(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s1 = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s1", t);
-		ApgSchExp s2 = new ApgSchExpVar("s2");
-		r.defs.apgschemas.put("s2", t);
-		ApgSchExp s = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s1);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s2);
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-		ApgTransExpVar k = new ApgTransExpVar("k");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-		r.defs.apgms.put("k", new Pair<>(G, G1));
-
-		return new ApgTransExpEqualizeU(h1, h2, k);
-	}
-
-	@Override
-	public ApgInstExpCoEqualize visitApgInstExpCoEqualize(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s = new ApgSchExpVar("s1");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-
-		return new ApgInstExpCoEqualize(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpCoEqualize(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-
-		return new ApgTransExpCoEqualize(h1, h2);
-	}
-
-	@Override
-	public ApgTransExp visitApgTransExpCoEqualizeU(Unit params, AqlTyping r) {
-		ApgTyExp t = new ApgTyExpVar("t");
-		r.defs.apgts.put("t", Unit.unit);
-
-		ApgSchExp s = new ApgSchExpVar("s");
-		r.defs.apgschemas.put("s", t);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", s);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", s);
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", s);
-
-		ApgTransExpVar h1 = new ApgTransExpVar("h");
-		ApgTransExpVar h2 = new ApgTransExpVar("h'");
-		ApgTransExpVar k = new ApgTransExpVar("k");
-
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-		r.defs.apgms.put("h'", new Pair<>(G1, G2));
-		r.defs.apgms.put("k", new Pair<>(G2, G));
-
-		return new ApgTransExpCoEqualizeU(h1, h2, k);
-	}
-
-	@Override
-	public ApgInstExpDelta visitApgInstExpDelta(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp t = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-		ApgSchExp s = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-
-		ApgInstExp G = new ApgInstExpVar("G");
-		r.defs.apgis.put("G", t);
-
-		ApgMapExp F = new ApgMapExpVar("F");
-		r.defs.apgmappings.put("F", new Pair<>(s, t));
-
-		return new ApgInstExpDelta(F, G);
-
-	}
-
-	@Override
-	public ApgTransExpDelta visitApgTransExpDelta(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp t = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-		ApgSchExp s = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-
-		ApgInstExp G1 = new ApgInstExpVar("G1");
-		r.defs.apgis.put("G1", t);
-		ApgInstExp G2 = new ApgInstExpVar("G2");
-		r.defs.apgis.put("G2", t);
-
-		ApgMapExp F = new ApgMapExpVar("F");
-		r.defs.apgmappings.put("F", new Pair<>(s, t));
-
-		ApgTransExp h = new ApgTransExpVar("h");
-		r.defs.apgms.put("h", new Pair<>(G1, G2));
-
-		return new ApgTransExpDelta(F, h);
-	}
-
-	@Override
-	public ApgSchExpInitial visitApgSchExpInitial(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		return new ApgSchExpInitial(ty);
-	}
-
-	@Override
-	public ApgSchExpTerminal visitApgSchExpTerminal(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		return new ApgSchExpTerminal(ty);
-	}
-
-	@Override
-	public ApgSchExpTimes visitApgSchExpTimes(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp S = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-		ApgSchExp T = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-
-		return new ApgSchExpTimes(S, T);
-	}
-
-	@Override
-	public ApgSchExpPlus visitApgSchExpPlus(Unit params, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp S = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-		ApgSchExp T = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-
-		return new ApgSchExpPlus(S, T);
-	}
-
-	@Override
-	public ApgSchExpVar visitApgSchExpVar(Unit param, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExpVar x = new ApgSchExpVar("v");
-		r.defs.apgschemas.put("v", ty);
-		return x;
-	}
-
-	@Override
-	public ApgSchExpRaw visitApgSchExpRaw(Unit param, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		return new ApgSchExpRaw(ty, Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public ApgMapExpVar visitApgMapExpVar(Unit param, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp S = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-		ApgSchExp T = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-
-		ApgMapExpVar x = new ApgMapExpVar("v");
-		r.defs.apgmappings.put("v", new Pair<>(S, T));
-		return x;
-	}
-
-	@Override
-	public ApgMapExpRaw visitApgMapExpRaw(Unit param, AqlTyping r) {
-		ApgTyExp ty = new ApgTyExpVar("ty");
-		r.defs.apgts.put("ty", Unit.unit);
-
-		ApgSchExp S = new ApgSchExpVar("S");
-		r.defs.apgschemas.put("S", ty);
-		ApgSchExp T = new ApgSchExpVar("T");
-		r.defs.apgschemas.put("T", ty);
-
-		return new ApgMapExpRaw(S, T, Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public SchExpCsv visitSchExpCsv(Unit params, AqlTyping r) {
-		return new SchExpCsv("filename", Collections.emptyList(), new TyExpSql());
-	}
-
-	@Override
-	public InstExpRdfAll visitInstExpRdfAll(Unit param, AqlTyping exp) {
-		return new InstExpRdfAll("rdf_uri", Collections.emptyList());
-	}
-
-	@Override
-	public InstExpJsonAll visitInstExpJsonAll(Unit param, AqlTyping exp) {
-		return new InstExpJsonAll("json_uri", Collections.emptyList());
-	}
-
-	@Override
-	public InstExpXmlAll visitInstExpXmlAll(Unit param, AqlTyping exp) {
-		return new InstExpXmlAll("xml_uri", Collections.emptyList());
-	}
-
-	@Override
-	public <X, Y> PragmaExpJsonInstExport<X, Y> visitPragmaExpJsonInstExport(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpJsonInstExport(i, "json_file", new LinkedList<>(), new LinkedList<>());
-	}
-
-	@Override
-	public <X, Y> PragmaExpRdfInstExport<X, Y> visitPragmaExpRdfInstExport(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpRdfInstExport(i, "rdf_file", new LinkedList<>(), new LinkedList<>());
-	}
-
-	@Override
-	public InstExpXmlAll visitInstExpMarkdown(Unit param, AqlTyping exp) {
-		return new InstExpXmlAll("md_uri", Collections.emptyList());
-	}
-
-	@Override
-	public InstExpSpanify visitInstExpSpanify(Unit param, AqlTyping exp) {
-		SchExp s = InstExpRdfAll.makeSch();
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", new TyExpRdf());
-		exp.defs.insts.put("i", s);
-		return new InstExpSpanify(i, Collections.emptyList());
-	}
-
-	@Override
-	public <X, Y> PragmaExpRdfDirectExport<X, Y> visitPragmaExpRdfDirectExport(Unit params, AqlTyping exp) {
-		SchExp s = InstExpRdfAll.makeSch();
-		TyExp t = new TyExpRdf();
-		InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new PragmaExpRdfDirectExport(i, "rdf_file", new LinkedList<>(), new LinkedList<>());
-	}
-
-	@Override
-	public SchExpSpan visitSchExpSpan(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new SchExpSpan(s);
-	}
-
-	@Override
-	public SchExpRdf visitSchExpRdf(Unit params, AqlTyping exp) {
-		return new SchExpRdf();
-	}
-
-	@Override
-	public SchExpMsCatalog visitSchExpMsCatalog(Unit params, AqlTyping r) {
-		return new SchExpMsCatalog(new TyExpSql(), "Other");
-	}
-
-	@Override
-	public SchExpMsQuery visitSchExpMsQuery(Unit params, AqlTyping r) {
-		return new SchExpMsQuery(new TyExpSql(), "Other");
-	}
-
-	@Override
-	public InstExpJdbcDirect visitInstExpJdbcDirect(Unit param, AqlTyping exp) {
-		return new InstExpJdbcDirect(new SchExpEmpty(new TyExpEmpty()), Collections.emptyList(), "jdbcString",
-				"ROW_NUMBER() OVER()");
-	}
-
-	@Override
-	public QueryExpSpanify visitQueryExpSpanify(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new QueryExpSpanify(s);
-	}
-
-	@Override
-	public QueryExpMapToSpanQuery visitQueryExpMapToSpanQuery(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		SchExp s2 = new SchExpVar("s2");
-		exp.defs.schs.put("s2", t);
-		return new QueryExpMapToSpanQuery(
-				new MapExpRaw(s, s2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
-	}
-
-	@Override
-	public SchExpPrefix visitSchExpPrefix(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new SchExpPrefix(s, "prefix");
-	}
-
-	@Override
-	public MapExpToPrefix visitMapExpToPrefix(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new MapExpToPrefix(s, "prefix");
-	}
-
-	@Override
-	public MapExpFromPrefix visitMapExpFromPrefix(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new MapExpFromPrefix(s, "prefix");
-	}
-
-	@Override
-	public EdsExpSqlNull visitEdsExpSqlNull(Unit params, AqlTyping exp) {
-		TyExp ty = new TyExpVar("ty");
-		exp.defs.tys.put("ty", Unit.unit);
-		return new EdsExpSqlNull(ty);
-	}
-
-	@Override
-	public EdsExpInclude visitEdsExpInclude(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpRdf();
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", t);
-		return new EdsExpInclude(s, "old", "new", Collections.emptyList());
-	}
-
-	@Override
-	public SchExpMsError visitSchExpMsError(Unit params, AqlTyping exp) {
-		return new SchExpMsError("Other", "jdbc_string", new TyExpSql());
-	}
-
-	@Override
-	public InstExpMsError visitInstExpMsError(Unit param, AqlTyping exp) {
-		return new InstExpMsError("Other", "jdbc_string", new TyExpSql());
-	}
-
-	@Override
-	public SchExpMsErrorShallow visitSchExpMsErrorShallow(Unit param, AqlTyping exp) {
-		return new SchExpMsErrorShallow("Other", new TyExpSql());
-	}
-
-	@Override
-	public SchExpFromMsCatalog visitSchExpFromMsCatalog(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpMsQuery(new TyExpSql(), "Other");
-		InstExp i = new InstExpVar("i");
-		exp.defs.insts.put("i", s);
-		return new SchExpFromMsCatalog(i, Collections.emptyList());
-	}
-
-	@Override
-	public QueryExpFront visitQueryExpFront(Unit params, AqlTyping exp) {
-		SchExpVar e = new SchExpVar("s");
-		TyExpVar x = new TyExpVar("t");
-		EdsExpVar eds = new EdsExpVar("eds");
-		exp.defs.eds.put("eds", e);
-		exp.defs.schs.put("s", x);
-		return new QueryExpFront(eds, "0", true, Collections.emptyList());
-	}
-
-	@Override
-	public SchExpFront visitSchExpFront(Unit params, AqlTyping exp) {
-		SchExpVar e = new SchExpVar("s");
-		TyExpVar x = new TyExpVar("t");
-		EdsExpVar eds = new EdsExpVar("eds");
-		exp.defs.eds.put("eds", e);
-		exp.defs.schs.put("s", x);
-		return new SchExpFront(eds, "0");
-	}
-
-	@Override
-	public InstExpTinkerpop visitInstExpTinkerpop(Unit param, AqlTyping exp) {
-		TyExp t = new TyExpSql();
-		exp.defs.schs.put("s", t);
-		return new InstExpTinkerpop(new LinkedList());
-	}
-
-	@Override
-	public SchExpTinkerpop visitSchExpTinkerpop(Unit params, AqlTyping exp) {
-		return new SchExpTinkerpop();
-	}
-
-	@Override
-	public EdsExpTinkerpop visitEdsExpTinkerpop(Unit params, AqlTyping exp) {
-		return new EdsExpTinkerpop();
-	}
-
-	@Override
-	public PragmaExpBitsy visitPragmaExpBitsy(Unit params, AqlTyping exp) {
-		return new PragmaExpBitsy(Collections.emptyList());
-	}
-
-	@Override
-	public PragmaExpTinkerpopInstExport visitPragmaExpTinkerpopInstExport(Unit params, AqlTyping exp) {
-		SchExpVar e = new SchExpVar("s");
-		TyExpVar x = new TyExpVar("t");
-		InstExpVar i = new InstExpVar("i");
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.schs.put("s", x);
-		exp.defs.insts.put("i", e);
-		return new PragmaExpTinkerpopInstExport(i, Collections.emptyList());
-	}
-
-	@Override
-	public PragmaExpTinkerpop visitPragmaExpTinkerpop(Unit params, AqlTyping exp) {
-		return new PragmaExpTinkerpop(Collections.emptyList(), Collections.emptyList());
-	}
-
-	@Override
-	public EdsExpFromMsCatalog visitEdsExpFromMsCatalog(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpMsQuery(new TyExpSql(), "Other");
-		InstExp i = new InstExpVar("i");
-		exp.defs.insts.put("i", s);
-		return new EdsExpFromMsCatalog(i, s, Collections.emptyList());
-	}
-
-	@Override
-	public ColimSchExpSimplify visitColimSchExpSimplify(Unit params, AqlTyping exp) {
-		ColimSchExp x = new ColimSchExpVar("sc");
-		exp.defs.scs.put("sc", new THashSet());
-
-		return new ColimSchExpSimplify(x, Collections.emptyList());
-	}
-
-	@Override
-	public EdsExpSigma visitEdsExpSigma(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		EdsExp c = new EdsExpVar("c");
-		MapExp m = new MapExpVar("m");
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.maps.put("m", new Pair(s1, s2));
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.eds.put("c", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		exp.prog.exps.put("c", new EdsExpRaw(s1, Collections.emptyList(), Collections.emptyList(), Unit.unit));
-		exp.prog.exps.put("m", m);
-
-		return new EdsExpSigma(m, c);
-	}
-
-	@Override
-	public EdsExpSql visitEdsExpSql(Unit params, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpSql();
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		return new EdsExpSql(s);
-	}
-
-	@Override
-	public ColimSchExpPseudo visitColimSchExpPseudo(Unit params, AqlTyping exp) {
-		TyExp t = new TyExpVar("t");
-		exp.defs.tys.put("t", Unit.unit);
-		return new ColimSchExpPseudo(t, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-				Collections.emptyList());
-	}
-
-	@Override
-	public MapExpPseudo visitMapExpPseudo(Unit params, AqlTyping exp) {
-		exp.defs.scs.put("c", Collections.emptySet());
-		return new MapExpPseudo(new ColimSchExpVar("c"));
-	}
-
-	@Override
-	public QueryExpRext visitQueryExpRext(Unit params, AqlTyping exp) {
-		exp.defs.tys.put("t", Unit.unit);
-		TyExpVar t = new TyExpVar("t");
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.schs.put("s3", t);
-
-		SchExpVar s1 = new SchExpVar("s1");
-		SchExpVar s2 = new SchExpVar("s2");
-		SchExpVar s3 = new SchExpVar("s3");
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("s3", new SchExpEmpty(t));
-
-		QueryExpVar m12 = new QueryExpVar("q12");
-		QueryExpVar m13 = new QueryExpVar("q13");
-
-		exp.defs.qs.put("q12", new Pair(s1, s2));
-		exp.defs.qs.put("q13", new Pair(s1, s3));
-
-		return new QueryExpRext(m12, m13, Collections.emptyList());
-	}
-
-	@Override
-	public SchExpUnit visitSchExpUnit(Unit params, AqlTyping r) {
-		TyExp t = new TyExpVar("t");
-		r.defs.tys.put("t", Unit.unit);
-		return new SchExpUnit(t);
-
-	}
-
-	@Override
-	public QueryExpFromInst visitQueryExpFromInst(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s1);
-		return new QueryExpFromInst(i);
-	}
-
-	@Override
-	public EdsExpLearn visitEdsExpLearn(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i1");
-		InstExp j = new InstExpVar("i2");
-		exp.defs.schs.put("s1", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i1", s1);
-		exp.defs.insts.put("i2", s1);
-
-		return new EdsExpLearn(i, j);
-	}
-
-	@Override
-	public QueryExpChase visitQueryExpChase(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.qs.put("q", new Pair<>(s1, s2));
-		exp.defs.eds.put("c", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		EdsExpVar c = new EdsExpVar("c");
-		return new QueryExpChase(q, c);
-	}
-
-	@Override
-	public QueryExpReformulate visitQueryExpReformulate(Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		QueryExp q = new QueryExpVar("q");
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.qs.put("q", new Pair<>(s1, s2));
-		exp.defs.eds.put("c", s1);
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-		EdsExpVar c = new EdsExpVar("c");
-		return new QueryExpReformulate(q, c, s2, "0");
-	}
-
-	@Override
-	public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> TransExpSubseteq<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpSubseteq(
-			Unit params, AqlTyping exp) {
-		SchExp s1 = new SchExpVar("s1");
-		SchExp s2 = new SchExpVar("s2");
-		TyExp t = new TyExpVar("t");
-		QueryExp q1 = new QueryExpVar("q1");
-		QueryExp q2 = new QueryExpVar("q2");
-
-		exp.defs.schs.put("s1", t);
-		exp.defs.schs.put("s2", t);
-
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.qs.put("q1", new Pair<>(s1, s2));
-		exp.defs.qs.put("q2", new Pair<>(s1, s2));
-
-		exp.prog.exps.put("s1", new SchExpEmpty(t));
-		exp.prog.exps.put("s2", new SchExpEmpty(t));
-		exp.prog.exps.put("t", new TyExpEmpty());
-
-		return new TransExpSubseteq(q1, q2);
-	}
-
-	@Override
-	public <Gen, Sk, X, Y> InstExpCore<Gen, Sk, X, Y> visitInstExpCore(Unit param, AqlTyping exp) {
-		SchExp s = new SchExpVar("s");
-		TyExp t = new TyExpVar("t");
-		InstExp i = new InstExpVar("i");
-		exp.defs.schs.put("s", t);
-		exp.defs.tys.put("t", Unit.unit);
-		exp.defs.insts.put("i", s);
-		return new InstExpCore(i);
-	}
-
-	@Override
-	public EdsExpInfer visitEdsExpInfer(Unit params, AqlTyping exp) throws RuntimeException {
-		System.exit(666);
-		return null;
-	}
+  @Override
+  public TyExpSch visitTyExpSch(Unit params, AqlTyping exp) {
+    SchExpVar e = new SchExpVar("s");
+    TyExpVar x = new TyExpVar("t");
+    TyExpSch t = new TyExpSch(e);
+    exp.defs.schs.put("s", x);
+    exp.defs.tys.put("t", Unit.unit);
+    return t;
+  }
+
+  @Override
+  public TyExpEmpty visitTyExpEmpty(Unit params, AqlTyping exp) {
+    return new TyExpEmpty();
+  }
+
+  @Override
+  public TyExpLit visitTyExpLit(Unit params, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public TyExpVar visitTyExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar e = new TyExpVar("t");
+    return e;
+  }
+
+  @Override
+  public TyExpRaw visitTyExpRaw(Unit params, AqlTyping exp) {
+    return new TyExpRaw(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public TyExpSql visitTyExpSql(Unit params, AqlTyping exp) {
+    return new TyExpSql();
+  }
+
+  @Override
+  public TyExpRdf visitTyExpRdf(Unit params, AqlTyping exp) {
+    return new TyExpRdf();
+  }
+
+  @Override
+  public SchExpCod visitSchExpCod(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new SchExpCod(new QueryExpVar("q"));
+  }
+
+  @Override
+  public SchExpDom visitSchExpDom(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new SchExpDom(new QueryExpVar("q"));
+  }
+
+  @Override
+  public SchExpDst visitSchExpDst(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new SchExpDst(new MapExpVar("m"));
+  }
+
+  @Override
+  public SchExpSrc visitSchExpSrc(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new SchExpSrc(new MapExpVar("m"));
+  }
+
+  @Override
+  public SchExpEmpty visitSchExpEmpty(Unit params, AqlTyping exp) {
+    TyExp t = new TyExpVar("t");
+    exp.defs.tys.put("t", Unit.unit);
+    return new SchExpEmpty(t);
+  }
+
+  // Documentation-only prototype: SchExpDiff is dispatched via visitSchExpPrefix in
+  // coaccept, so it has no interface method; AqlHelp reaches it reflectively by name.
+  public SchExpDiff visitSchExpDiff(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    return new SchExpDiff(s1, s2);
+  }
+
+  @Override
+  public SchExpInst visitSchExpInst(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    exp.prog.exps.put("i", i);
+    return new SchExpInst(i);
+  }
+
+  @Override
+  public SchExpLit visitSchExpLit(Unit params, AqlTyping exp) {
+    return null;
+    //    return new SchExpLit(Schema.terminal(TypeSide.initial()));
+  }
+
+  @Override
+  public SchExpPivot visitSchExpPivot(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp x = new TyExpVar("t");
+    InstExp q = new InstExpVar("i");
+    exp.defs.schs.put("s", x);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new SchExpPivot(q, new LinkedList());
+  }
+
+  @Override
+  public SchExpVar visitSchExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar e = new TyExpVar("t");
+    exp.defs.schs.put("s", e);
+    return new SchExpVar("s");
+  }
+
+  @Override
+  public SchExpRaw visitSchExpRaw(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar e = new TyExpVar("t");
+    return new SchExpRaw(
+        e,
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList(),
+        new LinkedList());
+  }
+
+  @Override
+  public SchExpColim visitSchExpColim(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    ColimSchExp x = new ColimSchExpVar("sc");
+    exp.defs.scs.put("sc", new THashSet());
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    exp.prog.exps.put("sc", q);
+    return new SchExpColim(x);
+  }
+
+  @Override
+  public MapExpComp visitMapExpComp(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.schs.put("s3", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+    SchExpVar s3 = new SchExpVar("s3");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("s3", new SchExpEmpty(t));
+
+    MapExpVar m12 = new MapExpVar("m12");
+    MapExpVar m23 = new MapExpVar("m23");
+
+    exp.defs.maps.put("m12", new Pair(s1, s2));
+    exp.defs.maps.put("m23", new Pair(s2, s3));
+
+    return new MapExpComp(m12, m23);
+  }
+
+  @Override
+  public MapExpId visitMapExpId(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+
+    exp.defs.schs.put("s", t);
+    SchExpVar s = new SchExpVar("s");
+
+    return new MapExpId(s);
+  }
+
+  @Override
+  public QueryExpVar visitQueryExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new QueryExpVar("q");
+  }
+
+  @Override
+  public QueryExpRaw visitQueryExpRaw(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    // exp.defs.qs.put("q", new Pair(s1, s2));
+    return new QueryExpRaw(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        s1,
+        s2,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> MapExpPivot<Gen, Sk, X, Y> visitMapExpPivot(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp x = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", x);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    //    String l = new SchExpPivot(q, new LinkedList());
+    return new MapExpPivot(i, new LinkedList());
+  }
+
+  @Override
+  public MapExpVar visitMapExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new MapExpVar("m");
+  }
+
+  @Override
+  public MapExpRaw visitMapExpRaw(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    //    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new MapExpRaw(
+        s1, s2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public MapExpColim visitMapExpColim(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.scs.put("sc", new THashSet());
+    exp.defs.schs.put("s", t);
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.singletonList(new LocStr(0, "s")),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    exp.prog.exps.put("sc", q);
+    return new MapExpColim("s", q);
+  }
+
+  @Override
+  public QueryExpCompose visitQueryExpCompose(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.schs.put("s3", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+    SchExpVar s3 = new SchExpVar("s3");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("s3", new SchExpEmpty(t));
+
+    QueryExpVar m12 = new QueryExpVar("q12");
+    QueryExpVar m23 = new QueryExpVar("q23");
+
+    exp.defs.qs.put("q12", new Pair(s1, s2));
+    exp.defs.qs.put("q23", new Pair(s2, s3));
+
+    return new QueryExpCompose(m12, m23, Collections.emptyList());
+  }
+
+  @Override
+  public QueryExpId visitQueryExpId(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+
+    exp.defs.schs.put("s", t);
+    SchExpVar s = new SchExpVar("s");
+
+    return new QueryExpId(s);
+  }
+
+  @Override
+  public QueryExpLit visitQueryExpLit(Unit params, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public QueryExpDeltaCoEval visitQueryExpDeltaCoEval(Unit params, AqlTyping exp) {
+
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+
+    MapExp m = new MapExpVar("m");
+
+    exp.defs.maps.put("m", new Pair(s1, s2));
+
+    return new QueryExpDeltaCoEval(m, Collections.emptyList());
+  }
+
+  @Override
+  public QueryExpDeltaEval visitQueryExpDeltaEval(Unit params, AqlTyping exp) {
+
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+
+    MapExpVar m = new MapExpVar("m");
+
+    exp.defs.maps.put("m", new Pair(s1, s2));
+
+    return new QueryExpDeltaEval(m, Collections.emptyList());
+  }
+
+  @Override
+  public QueryExpRawSimple visitQueryExpRawSimple(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s", t);
+    SchExp s1 = new SchExpVar("s");
+    return new QueryExpRawSimple(s1);
+  }
+
+  @Override
+  public EdsExpVar visitEdsExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    SchExpVar s = new SchExpVar("s");
+
+    exp.defs.schs.put("s", t);
+    exp.defs.eds.put("c", s);
+
+    return new EdsExpVar("c");
+  }
+
+  @Override
+  public EdsExpRaw visitEdsExpRaw(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    SchExpVar s = new SchExpVar("s");
+    exp.defs.schs.put("s", t);
+
+    return new EdsExpRaw(s, Collections.emptyList(), Collections.emptyList(), Unit.unit);
+  }
+
+  @Override
+  public GraphExpRaw visitGraphExpRaw(Unit params, AqlTyping exp) {
+    return new GraphExpRaw(
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public GraphExpVar visitGraphExpVar(Unit params, AqlTyping exp) {
+    exp.defs.gs.put("g", Unit.unit);
+    return new GraphExpVar("g");
+  }
+
+  @Override
+  public GraphExpLiteral visitGraphExpLiteral(Unit params, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public <X, Y> PragmaExpConsistent<X, Y> visitPragmaExpConsistent(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpConsistent(i);
+  }
+
+  @Override
+  public <X, Y> PragmaExpCheck<X, Y> visitPragmaExpCheck(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    EdsExp c = new EdsExpVar("c");
+    exp.defs.eds.put("c", s);
+    return new PragmaExpCheck(i, c, Collections.emptyList());
+  }
+
+  @Override
+  public PragmaExpMatch visitPragmaExpMatch(Unit params, AqlTyping exp) {
+    exp.defs.gs.put("g1", Unit.unit);
+    exp.defs.gs.put("g2", Unit.unit);
+    GraphExp g1 = new GraphExpVar("g1");
+    GraphExp g2 = new GraphExpVar("g2");
+    return new PragmaExpMatch("method", g1, g2, Collections.emptyList());
+  }
+
+  @Override
+  public PragmaExpSql visitPragmaExpSql(Unit params, AqlTyping exp) {
+    return new PragmaExpSql("jdbc_string", Collections.emptyList(), new LinkedList());
+  }
+
+  @Override
+  public <X, Y> PragmaExpToCsvInst<X, Y> visitPragmaExpToCsvInst(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpToCsvInst(i, "directory", new LinkedList());
+  }
+
+  @Override
+  public PragmaExpVar visitPragmaExpVar(Unit params, AqlTyping exp) {
+    exp.defs.ps.put("p", Unit.unit);
+    PragmaExpVar e = new PragmaExpVar("p");
+    return e;
+  }
+
+  @Override
+  public PragmaExpJs visitPragmaExpJs(Unit params, AqlTyping exp) {
+    return new PragmaExpJs(Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public PragmaExpProc visitPragmaExpProc(Unit params, AqlTyping exp) {
+    return new PragmaExpProc(Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public <X, Y> PragmaExpToJdbcInst<X, Y> visitPragmaExpToJdbcInst(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpToJdbcInst(i, "jdbc_string", "prefix", new LinkedList());
+  }
+
+  @Override
+  public <Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2>
+      PragmaExpToJdbcTrans<Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> visitPragmaExpToJdbcTrans(
+          Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<Object, Object, Object, Object> i1 = new InstExpVar("i1");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    InstExp<Object, Object, Object, Object> i2 = new InstExpVar("i2");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    return new PragmaExpToJdbcTrans(h, "jdbc_string", "prefix", new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public PragmaExpToJdbcQuery visitPragmaExpToJdbcQuery(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    QueryExpVar q = new QueryExpVar("q");
+    return new PragmaExpToJdbcQuery(q, "jdbc_string", "prefix_src", "prefix_dst", new LinkedList());
+  }
+
+  @Override
+  public <Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2>
+      PragmaExpToCsvTrans<Gen1, Sk1, X1, Y1, Gen2, Sk2, X2, Y2> visitPragmaExpToCsvTrans(
+          Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<Object, Object, Object, Object> i1 = new InstExpVar("i1");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    InstExp<Object, Object, Object, Object> i2 = new InstExpVar("i2");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    return new PragmaExpToCsvTrans(h, "directory", new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public PragmaExpCheck2 visitPragmaExpCheck2(Unit params, AqlTyping exp) {
+    TyExpVar t = new TyExpVar("t");
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    QueryExp q = new QueryExpVar("q");
+
+    exp.defs.eds.put("c1", s1);
+    exp.defs.eds.put("c2", s2);
+
+    EdsExp c1 = new EdsExpVar("c1");
+    EdsExp c2 = new EdsExpVar("c2");
+
+    return new PragmaExpCheck2(q, c1, c2);
+  }
+
+  @Override
+  public ColimSchExpQuotient visitColimSchExpQuotient(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    return q;
+  }
+
+  @Override
+  public ColimSchExpRaw visitColimSchExpRaw(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.defs.gs.put("g", Unit.unit);
+    GraphExp g = new GraphExpVar("g");
+    return new ColimSchExpRaw(g, t, new LinkedList(), new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public ColimSchExpVar visitColimSchExpVar(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    ColimSchExpVar x = new ColimSchExpVar("sc");
+    exp.defs.scs.put("sc", new THashSet());
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    exp.prog.exps.put("sc", q);
+    return x;
+  }
+
+  @Override
+  public ColimSchExpWrap visitColimSchExpWrap(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    ColimSchExpVar x = new ColimSchExpVar("sc");
+    exp.defs.scs.put("sc", new THashSet());
+    SchExp s = new SchExpVar("s");
+    SchExp ss = new SchExpColim(x);
+
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    exp.prog.exps.put("sc", q);
+
+    MapExp m1 = new MapExpVar("m1");
+    MapExp m2 = new MapExpVar("m2");
+    exp.defs.maps.put("m1", new Pair(ss, s));
+    exp.defs.maps.put("m2", new Pair(s, ss));
+
+    return new ColimSchExpWrap(x, m1, m2);
+  }
+
+  @Override
+  public ColimSchExpModify visitColimSchExpModify(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    ColimSchExpVar x = new ColimSchExpVar("sc");
+    exp.defs.scs.put("sc", new THashSet());
+
+    ColimSchExpQuotient q =
+        new ColimSchExpQuotient(
+            t,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+    exp.prog.exps.put("sc", q);
+
+    return new ColimSchExpModify(
+        x,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpSigma<Gen, Sk, X, Y> visitInstExpSigma(Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.insts.put("i", s1);
+    MapExpVar m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new InstExpSigma(m, i, Collections.emptyMap());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpSigmaChase<Gen, Sk, X, Y> visitInstExpSigmaChase(
+      Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.defs.insts.put("i", s1);
+    MapExpVar m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new InstExpSigmaChase(m, i, Collections.emptyMap());
+  }
+
+  @Override
+  public InstExpVar visitInstExpVar(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExpVar i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return i;
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpAnonymize<Gen, Sk, X, Y> visitInstExpAnonymize(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<Object, Object, Object, Object> i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new InstExpAnonymize(i);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpChase<Gen, Sk, X, Y> visitInstExpChase(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    exp.defs.eds.put("c", s);
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    EdsExpVar c = new EdsExpVar("c");
+    return new InstExpChase(c, i, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      InstExpCoEq<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpCoEq(
+          Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    TransExpVar h1 = new TransExpVar("h1");
+    exp.defs.trans.put("h1", new Pair(i1, i2));
+    TransExpVar h2 = new TransExpVar("h2");
+    exp.defs.trans.put("h2", new Pair(i1, i2));
+
+    return new InstExpCoEq(h1, h2, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpColim<Gen, Sk, X, Y> visitInstExpColim(Unit param, AqlTyping exp) {
+    GraphExpVar g = new GraphExpVar("g");
+    SchExp s = new SchExpVar("s");
+    exp.defs.tys.put("t", Unit.unit);
+    return new InstExpColim(
+        g, s, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpCoProdFull<Gen, Sk, X, Y> visitInstExpCoProdFull(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    List<String> l = new LinkedList();
+    l.add("i1");
+    l.add("i2");
+    return new InstExpCoProdFull(l, s, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y, Gen1, Sk1, X1> InstExpDiff<Gen, Sk, X, Y, Gen1, Sk1, X1> visitInstExpDiff(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    return new InstExpDiff(i1, i2);
+  }
+
+  // Documentation-only prototype: InstExpInclude has no interface visit method;
+  // AqlHelp reaches it reflectively by name to render its syntax page.
+  public <Gen, Sk, X, Y> InstExpInclude<Gen, Sk, X, Y> visitInstExpInclude(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i", s);
+    return new InstExpInclude(i, s);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpDistinct<Gen, Sk, X, Y> visitInstExpDistinct(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new InstExpDistinct(i);
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      InstExpDom<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpDom(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    TransExpVar h = new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    return new InstExpDom(h);
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      InstExpCod<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitInstExpCod(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    TransExpVar h = new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    return new InstExpCod(h);
+  }
+
+  @Override
+  public InstExpEmpty visitInstExpEmpty(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    return new InstExpEmpty(s);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpEval<Gen, Sk, X, Y> visitInstExpEval(Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    QueryExpVar q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new InstExpEval(q, i, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpCoEval<Gen, Sk, X, Y> visitInstExpCoEval(
+      Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.insts.put("i", s2);
+    QueryExpVar q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new InstExpCoEval(q, i, Collections.emptyList());
+  }
+
+  @Override
+  public InstExpFrozen visitInstExpFrozen(Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    QueryExpVar q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new InstExpFrozen(q, "an_entity_or_type");
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpLit<Gen, Sk, X, Y> visitInstExpLit(Unit param, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpPivot<Gen, Sk, X, Y> visitInstExpPivot(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new InstExpPivot(i, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpPi<Gen, Sk, X, Y> visitInstExpPi(Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    MapExpVar m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    return new InstExpPi(m, i, Collections.emptyMap());
+  }
+
+  @Override
+  public InstExpCsv visitInstExpCsv(Unit param, AqlTyping exp) {
+    TyExp t = new TyExpSql();
+    return new InstExpCsv(t, new LinkedList(), new LinkedList(), "directory");
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpDelta<Gen, Sk, X, Y> visitInstExpDelta(Unit param, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    MapExpVar m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s2, s1));
+    return new InstExpDelta(m, i);
+  }
+
+  @Override
+  public InstExpJdbc visitInstExpJdbc(Unit param, AqlTyping exp) {
+    TyExp t = new TyExpSql();
+    return new InstExpJdbc(t, new LinkedList(), "jdbc_string", new LinkedList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpQueryQuotient<Gen, Sk, X, Y> visitInstExpQueryQuotient(
+      Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new InstExpQueryQuotient(i, Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public InstExpRandom visitInstExpRandom(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    return new InstExpRandom(s, new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public InstExpRaw visitInstExpRaw(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    return new InstExpRaw(
+        s,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpEval<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpEval(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpEval(q, h, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpCoEval<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpCoEval(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s2, s1));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpCoEval(q, h, new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpCoEvalEvalCoUnit<Gen, Sk, X, Y> visitTransExpCoEvalEvalCoUnit(
+      Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    InstExp i = new InstExpVar("i");
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+
+    return new TransExpCoEvalEvalCoUnit(q, i, new THashMap());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpCoEvalEvalUnit<Gen, Sk, X, Y> visitTransExpCoEvalEvalUnit(
+      Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s2, s1));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    InstExp i = new InstExpVar("i");
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+
+    return new TransExpCoEvalEvalUnit(q, i, new THashMap());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpSigmaDeltaCounit<Gen, Sk, X, Y> visitTransExpSigmaDeltaCounit(
+      Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    MapExp m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    InstExp i = new InstExpVar("i");
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+
+    return new TransExpSigmaDeltaCounit(m, i, new THashMap());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpSigmaDeltaUnit<Gen, Sk, X, Y> visitTransExpSigmaDeltaUnit(
+      Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    MapExp m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s2, s1));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    InstExp i = new InstExpVar("i");
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+
+    return new TransExpSigmaDeltaUnit(m, i, new THashMap());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2, Gen3, Sk3, X3, Y3>
+      TransExpCompose<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2, Gen3, Sk3, X3, Y3> visitTransExpCompose(
+          Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s", t);
+    SchExpVar s = new SchExpVar("s");
+
+    InstExpVar i1 = new InstExpVar("i1");
+    InstExpVar i2 = new InstExpVar("i2");
+    InstExpVar i3 = new InstExpVar("i3");
+
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    exp.defs.insts.put("i3", s);
+
+    exp.prog.exps.put("i1", new InstExpEmpty(s));
+    exp.prog.exps.put("i2", new InstExpEmpty(s));
+    exp.prog.exps.put("i3", new InstExpEmpty(s));
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+
+    TransExpVar h12 = new TransExpVar("h12");
+    TransExpVar h23 = new TransExpVar("h23");
+
+    exp.defs.trans.put("h12", new Pair(i1, i2));
+    exp.defs.trans.put("h23", new Pair(i2, i3));
+
+    return new TransExpCompose(h12, h23);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpId<Gen, Sk, X, Y> visitTransExpId(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i", s);
+    return new TransExpId(i);
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpDelta<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpDelta(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    MapExp m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s2, s1));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpDelta(m, h);
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpSigma<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpSigma(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    MapExp m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpSigma(m, h, new THashMap(), new THashMap());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpPi<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpPi(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    MapExp m = new MapExpVar("m");
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpPi(m, h, new THashMap(), new THashMap());
+  }
+
+  @Override
+  public TransExpRaw visitTransExpRaw(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    return new TransExpRaw(i1, i2, new LinkedList(), new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public TransExpVar visitTransExpVar(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    TransExpVar h = new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    return h;
+  }
+
+  @Override
+  public <X1, Y1, X2, Y2> TransExpCsv<X1, Y1, X2, Y2> visitTransExpCsv(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    return new TransExpCsv(i1, i2, new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public <X1, Y1, X2, Y2> TransExpJdbc<X1, Y1, X2, Y2> visitTransExpJdbc(
+      Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    return new TransExpJdbc("jdbc_string", i1, i2, new LinkedList(), new LinkedList());
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpDistinct<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpDistinct(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    InstExp j = new InstExpVar("j");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.defs.insts.put("j", s1);
+    InstExp i = new InstExpVar("i");
+    TransExp<Object, Object, Object, Object, Object, Object, Object, Object> h =
+        new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i, j));
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+    exp.prog.exps.put("j", new InstExpEmpty(s2));
+
+    return new TransExpDistinct(h);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpDistinct2<Gen, Sk, X, Y> visitTransExpDistinct2(
+      Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put("i", new InstExpEmpty(s1));
+
+    return new TransExpDistinct2(i);
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpLit<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpLit(
+          Unit params, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public MapExpLit visitMapExpLit(Unit params, AqlTyping exp) {
+    return null;
+  }
+
+  @Override
+  public CommentExp visitCommentExp(Unit params, AqlTyping exp) {
+    return new CommentExp("hello world", false);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> TransExpDiffReturn<Gen, Sk, X, Y> visitTransExpDiffReturn(
+      Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    return new TransExpDiffReturn(i1, i2);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y, Gen1, Gen2, Sk1, Sk2, X1, X2>
+      TransExpDiff<Gen, Sk, X, Y, Gen1, Gen2, Sk1, Sk2, X1, X2> visitTransExpDiff(
+          Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    InstExp i1 = new InstExpVar("i1");
+    InstExp i2 = new InstExpVar("i2");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    exp.defs.insts.put("i1", s);
+    exp.defs.insts.put("i2", s);
+    TransExp h = new TransExpVar("h");
+    exp.defs.trans.put("h", new Pair(i1, i2));
+    return new TransExpDiff(i, h);
+  }
+
+  @Override
+  public TransExpFrozen visitTransExpFrozen(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    QueryExpVar q = new QueryExpVar("q");
+    exp.defs.qs.put("q", new Pair(s1, s2));
+    return new TransExpFrozen(
+        q, "var", "entity", new RawTerm("term", Collections.emptyList()), "entity_or_type");
+  }
+
+  @Override
+  public QueryExpFromCoSpan visitQueryExpFromCoSpan(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.schs.put("s3", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+    SchExpVar s3 = new SchExpVar("s3");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("s3", new SchExpEmpty(t));
+
+    MapExpVar m12 = new MapExpVar("m12");
+    MapExpVar m32 = new MapExpVar("m32");
+
+    exp.defs.maps.put("m12", new Pair(s1, s2));
+    exp.defs.maps.put("m32", new Pair(s3, s2));
+
+    return new QueryExpFromCoSpan(m12, m32, Collections.emptyList());
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpCascadeDelete<Gen, Sk, X, Y> visitInstExpCascadeDelete(
+      Unit param, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    // exp.defs.schs.put("s2", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    //    SchExpVar s2 = new SchExpVar("s2");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    //    exp.prog.exps.put("s2", new SchExpEmpty(t));
+
+    InstExp i = new InstExpVar("i");
+    exp.defs.insts.put("i", s1);
+
+    return new InstExpCascadeDelete(i, s1);
+  }
+
+  @Override
+  public SchExpJdbcAll visitSchExpJdbcAll(Unit params, AqlTyping r) {
+    return new SchExpJdbcAll("jdbc_string", new LinkedList());
+  }
+
+  @Override
+  public QueryExpFromEds visitQueryExpFromEds(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.defs.schs.put("s", t);
+    exp.defs.eds.put(
+        "eds",
+        new SchExpVar("s")); // , Collections.emptyList(), Collections.emptyList(), Unit.unit));
+    EdsExpVar eds = new EdsExpVar("eds");
+
+    return new QueryExpFromEds(eds, 0);
+  }
+
+  @Override
+  public EdsExpSch visitEdsExpSch(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.defs.schs.put("s", t);
+    SchExpVar s = new SchExpVar("s");
+    exp.prog.exps.put("s", new SchExpEmpty(t));
+
+    return new EdsExpSch(s);
+  }
+
+  @Override
+  public TyExp visitTyExpAdt(Unit params, AqlTyping r) {
+    return new TyExpAdt(
+        Collections.emptyMap(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public ApgTyExpVar visitApgTyExpVar(Unit params, AqlTyping r) {
+    r.defs.apgts.put("t", Unit.unit);
+    ApgTyExpVar e = new ApgTyExpVar("t");
+    return e;
+  }
+
+  @Override
+  public ApgTyExpRaw visitApgTyExpRaw(Unit params, AqlTyping r) {
+    return new ApgTyExpRaw(
+        Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public ApgInstExpInitial visitApgInstExpInitial(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    return new ApgInstExpInitial(s);
+  }
+
+  @Override
+  public ApgInstExpTerminal visitApgInstExpTerminal(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    return new ApgInstExpTerminal(t);
+  }
+
+  @Override
+  public ApgInstExpTimes visitApgInstExpTimes(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    ApgInstExpVar a = new ApgInstExpVar("G1");
+    ApgInstExpVar b = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G1", s);
+    r.defs.apgis.put("G2", s);
+    return new ApgInstExpTimes(a, b);
+  }
+
+  @Override
+  public ApgInstExpPlus visitApgInstExpPlus(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    ApgInstExpVar a = new ApgInstExpVar("G1");
+    ApgInstExpVar b = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G1", s);
+    r.defs.apgis.put("G2", s);
+    return new ApgInstExpPlus(a, b);
+  }
+
+  @Override
+  public ApgInstExpVar visitApgInstExpVar(Unit param, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    ApgInstExpVar a = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+    return a;
+  }
+
+  @Override
+  public ApgInstExpRaw visitApgInstExpRaw(Unit param, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    ApgInstExpRaw a = new ApgInstExpRaw(s, Collections.emptyList(), Collections.emptyList());
+    r.defs.apgis.put("G", s);
+    return a;
+  }
+
+  @Override
+  public ApgTransExpRaw visitApgTransExpRaw(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    return new ApgTransExpRaw(
+        G1, G2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public ApgTransExpVar visitApgTransExpVar(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    r.defs.apgis.put("G1", s1);
+    r.defs.apgis.put("G2", s2);
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    return new ApgTransExpVar("h");
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpInitial(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    r.defs.apgms.put("h", new Pair<>(new ApgInstExpInitial(s), G));
+    return new ApgTransExpVar("h");
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpTerminal(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    r.defs.apgms.put("h", new Pair<>(G, new ApgInstExpTerminal(t)));
+    return new ApgTransExpVar("h");
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpFst(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    return new ApgTransExpFst(G1, G2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpSnd(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    return new ApgTransExpSnd(G1, G2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpInl(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    return new ApgTransExpInl(G1, G2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpInr(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    return new ApgTransExpInr(G1, G2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpId(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    return new ApgTransExpId(G1);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpCase(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+    ApgSchExp s3 = new ApgSchExpVar("s3");
+    r.defs.apgschemas.put("s3", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s3);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G));
+    r.defs.apgms.put("h'", new Pair<>(G2, G));
+
+    return new ApgTransExpCase(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpPair(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G, G1));
+    r.defs.apgms.put("h'", new Pair<>(G, G2));
+
+    return new ApgTransExpPair(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpCompose(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s3 = new ApgSchExpVar("s3");
+    r.defs.apgschemas.put("s3", t);
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+    ApgInstExp G3 = new ApgInstExpVar("G3");
+    r.defs.apgis.put("G3", s3);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G2, G3));
+
+    return new ApgTransExpCompose(h1, h2);
+  }
+
+  @Override
+  public ApgInstExpEqualize visitApgInstExpEqualize(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+
+    return new ApgInstExpEqualize(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpEqualize(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+
+    return new ApgTransExpEqualize(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpEqualizeU(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s1 = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s1", t);
+    ApgSchExp s2 = new ApgSchExpVar("s2");
+    r.defs.apgschemas.put("s2", t);
+    ApgSchExp s = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s1);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s2);
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+    ApgTransExpVar k = new ApgTransExpVar("k");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+    r.defs.apgms.put("k", new Pair<>(G, G1));
+
+    return new ApgTransExpEqualizeU(h1, h2, k);
+  }
+
+  @Override
+  public ApgInstExpCoEqualize visitApgInstExpCoEqualize(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s = new ApgSchExpVar("s1");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+
+    return new ApgInstExpCoEqualize(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpCoEqualize(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+
+    return new ApgTransExpCoEqualize(h1, h2);
+  }
+
+  @Override
+  public ApgTransExp visitApgTransExpCoEqualizeU(Unit params, AqlTyping r) {
+    ApgTyExp t = new ApgTyExpVar("t");
+    r.defs.apgts.put("t", Unit.unit);
+
+    ApgSchExp s = new ApgSchExpVar("s");
+    r.defs.apgschemas.put("s", t);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", s);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", s);
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", s);
+
+    ApgTransExpVar h1 = new ApgTransExpVar("h");
+    ApgTransExpVar h2 = new ApgTransExpVar("h'");
+    ApgTransExpVar k = new ApgTransExpVar("k");
+
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+    r.defs.apgms.put("h'", new Pair<>(G1, G2));
+    r.defs.apgms.put("k", new Pair<>(G2, G));
+
+    return new ApgTransExpCoEqualizeU(h1, h2, k);
+  }
+
+  @Override
+  public ApgInstExpDelta visitApgInstExpDelta(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp t = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+    ApgSchExp s = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+
+    ApgInstExp G = new ApgInstExpVar("G");
+    r.defs.apgis.put("G", t);
+
+    ApgMapExp F = new ApgMapExpVar("F");
+    r.defs.apgmappings.put("F", new Pair<>(s, t));
+
+    return new ApgInstExpDelta(F, G);
+  }
+
+  @Override
+  public ApgTransExpDelta visitApgTransExpDelta(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp t = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+    ApgSchExp s = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+
+    ApgInstExp G1 = new ApgInstExpVar("G1");
+    r.defs.apgis.put("G1", t);
+    ApgInstExp G2 = new ApgInstExpVar("G2");
+    r.defs.apgis.put("G2", t);
+
+    ApgMapExp F = new ApgMapExpVar("F");
+    r.defs.apgmappings.put("F", new Pair<>(s, t));
+
+    ApgTransExp h = new ApgTransExpVar("h");
+    r.defs.apgms.put("h", new Pair<>(G1, G2));
+
+    return new ApgTransExpDelta(F, h);
+  }
+
+  @Override
+  public ApgSchExpInitial visitApgSchExpInitial(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    return new ApgSchExpInitial(ty);
+  }
+
+  @Override
+  public ApgSchExpTerminal visitApgSchExpTerminal(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    return new ApgSchExpTerminal(ty);
+  }
+
+  @Override
+  public ApgSchExpTimes visitApgSchExpTimes(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp S = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+    ApgSchExp T = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+
+    return new ApgSchExpTimes(S, T);
+  }
+
+  @Override
+  public ApgSchExpPlus visitApgSchExpPlus(Unit params, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp S = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+    ApgSchExp T = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+
+    return new ApgSchExpPlus(S, T);
+  }
+
+  @Override
+  public ApgSchExpVar visitApgSchExpVar(Unit param, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExpVar x = new ApgSchExpVar("v");
+    r.defs.apgschemas.put("v", ty);
+    return x;
+  }
+
+  @Override
+  public ApgSchExpRaw visitApgSchExpRaw(Unit param, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    return new ApgSchExpRaw(ty, Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public ApgMapExpVar visitApgMapExpVar(Unit param, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp S = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+    ApgSchExp T = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+
+    ApgMapExpVar x = new ApgMapExpVar("v");
+    r.defs.apgmappings.put("v", new Pair<>(S, T));
+    return x;
+  }
+
+  @Override
+  public ApgMapExpRaw visitApgMapExpRaw(Unit param, AqlTyping r) {
+    ApgTyExp ty = new ApgTyExpVar("ty");
+    r.defs.apgts.put("ty", Unit.unit);
+
+    ApgSchExp S = new ApgSchExpVar("S");
+    r.defs.apgschemas.put("S", ty);
+    ApgSchExp T = new ApgSchExpVar("T");
+    r.defs.apgschemas.put("T", ty);
+
+    return new ApgMapExpRaw(S, T, Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public SchExpCsv visitSchExpCsv(Unit params, AqlTyping r) {
+    return new SchExpCsv("filename", Collections.emptyList(), new TyExpSql());
+  }
+
+  @Override
+  public InstExpRdfAll visitInstExpRdfAll(Unit param, AqlTyping exp) {
+    return new InstExpRdfAll("rdf_uri", Collections.emptyList());
+  }
+
+  @Override
+  public InstExpJsonAll visitInstExpJsonAll(Unit param, AqlTyping exp) {
+    return new InstExpJsonAll("json_uri", Collections.emptyList());
+  }
+
+  @Override
+  public InstExpXmlAll visitInstExpXmlAll(Unit param, AqlTyping exp) {
+    return new InstExpXmlAll("xml_uri", Collections.emptyList());
+  }
+
+  @Override
+  public <X, Y> PragmaExpJsonInstExport<X, Y> visitPragmaExpJsonInstExport(
+      Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpJsonInstExport(i, "json_file", new LinkedList<>(), new LinkedList<>());
+  }
+
+  @Override
+  public <X, Y> PragmaExpRdfInstExport<X, Y> visitPragmaExpRdfInstExport(
+      Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpRdfInstExport(i, "rdf_file", new LinkedList<>(), new LinkedList<>());
+  }
+
+  @Override
+  public InstExpXmlAll visitInstExpMarkdown(Unit param, AqlTyping exp) {
+    return new InstExpXmlAll("md_uri", Collections.emptyList());
+  }
+
+  @Override
+  public InstExpSpanify visitInstExpSpanify(Unit param, AqlTyping exp) {
+    SchExp s = InstExpRdfAll.makeSch();
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", new TyExpRdf());
+    exp.defs.insts.put("i", s);
+    return new InstExpSpanify(i, Collections.emptyList());
+  }
+
+  @Override
+  public <X, Y> PragmaExpRdfDirectExport<X, Y> visitPragmaExpRdfDirectExport(
+      Unit params, AqlTyping exp) {
+    SchExp s = InstExpRdfAll.makeSch();
+    TyExp t = new TyExpRdf();
+    InstExp<String, String, X, Y> i = (InstExp<String, String, X, Y>) (Object) new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new PragmaExpRdfDirectExport(i, "rdf_file", new LinkedList<>(), new LinkedList<>());
+  }
+
+  @Override
+  public SchExpSpan visitSchExpSpan(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new SchExpSpan(s);
+  }
+
+  @Override
+  public SchExpRdf visitSchExpRdf(Unit params, AqlTyping exp) {
+    return new SchExpRdf();
+  }
+
+  @Override
+  public SchExpMsCatalog visitSchExpMsCatalog(Unit params, AqlTyping r) {
+    return new SchExpMsCatalog(new TyExpSql(), "Other");
+  }
+
+  @Override
+  public SchExpMsQuery visitSchExpMsQuery(Unit params, AqlTyping r) {
+    return new SchExpMsQuery(new TyExpSql(), "Other");
+  }
+
+  @Override
+  public InstExpJdbcDirect visitInstExpJdbcDirect(Unit param, AqlTyping exp) {
+    return new InstExpJdbcDirect(
+        new SchExpEmpty(new TyExpEmpty()),
+        Collections.emptyList(),
+        "jdbcString",
+        "ROW_NUMBER() OVER()");
+  }
+
+  @Override
+  public QueryExpSpanify visitQueryExpSpanify(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new QueryExpSpanify(s);
+  }
+
+  @Override
+  public QueryExpMapToSpanQuery visitQueryExpMapToSpanQuery(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    SchExp s2 = new SchExpVar("s2");
+    exp.defs.schs.put("s2", t);
+    return new QueryExpMapToSpanQuery(
+        new MapExpRaw(
+            s, s2, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
+  }
+
+  @Override
+  public SchExpPrefix visitSchExpPrefix(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new SchExpPrefix(s, "prefix");
+  }
+
+  @Override
+  public MapExpToPrefix visitMapExpToPrefix(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new MapExpToPrefix(s, "prefix");
+  }
+
+  @Override
+  public MapExpFromPrefix visitMapExpFromPrefix(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new MapExpFromPrefix(s, "prefix");
+  }
+
+  @Override
+  public EdsExpSqlNull visitEdsExpSqlNull(Unit params, AqlTyping exp) {
+    TyExp ty = new TyExpVar("ty");
+    exp.defs.tys.put("ty", Unit.unit);
+    return new EdsExpSqlNull(ty);
+  }
+
+  @Override
+  public EdsExpInclude visitEdsExpInclude(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpRdf();
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    return new EdsExpInclude(s, "old", "new", Collections.emptyList());
+  }
+
+  // Documentation-only prototype: EdsExpAll has no interface visit method;
+  // AqlHelp reaches it reflectively by name to render its syntax page.
+  public <Gen, Sk, X, Y> EdsExpAll<Gen, Sk, X, Y> visitEdsExpAll(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    exp.defs.insts.put("i", s);
+    return new EdsExpAll(i, s);
+  }
+
+  @Override
+  public SchExpMsError visitSchExpMsError(Unit params, AqlTyping exp) {
+    return new SchExpMsError("Other", "jdbc_string", new TyExpSql());
+  }
+
+  @Override
+  public InstExpMsError visitInstExpMsError(Unit param, AqlTyping exp) {
+    return new InstExpMsError("Other", "jdbc_string", new TyExpSql());
+  }
+
+  @Override
+  public SchExpMsErrorShallow visitSchExpMsErrorShallow(Unit param, AqlTyping exp) {
+    return new SchExpMsErrorShallow("Other", new TyExpSql());
+  }
+
+  @Override
+  public SchExpFromMsCatalog visitSchExpFromMsCatalog(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpMsQuery(new TyExpSql(), "Other");
+    InstExp i = new InstExpVar("i");
+    exp.defs.insts.put("i", s);
+    return new SchExpFromMsCatalog(i, Collections.emptyList());
+  }
+
+  @Override
+  public QueryExpFront visitQueryExpFront(Unit params, AqlTyping exp) {
+    SchExpVar e = new SchExpVar("s");
+    TyExpVar x = new TyExpVar("t");
+    EdsExpVar eds = new EdsExpVar("eds");
+    exp.defs.eds.put("eds", e);
+    exp.defs.schs.put("s", x);
+    return new QueryExpFront(eds, "0", true, Collections.emptyList());
+  }
+
+  @Override
+  public SchExpFront visitSchExpFront(Unit params, AqlTyping exp) {
+    SchExpVar e = new SchExpVar("s");
+    TyExpVar x = new TyExpVar("t");
+    EdsExpVar eds = new EdsExpVar("eds");
+    exp.defs.eds.put("eds", e);
+    exp.defs.schs.put("s", x);
+    return new SchExpFront(eds, "0");
+  }
+
+  @Override
+  public InstExpTinkerpop visitInstExpTinkerpop(Unit param, AqlTyping exp) {
+    TyExp t = new TyExpSql();
+    exp.defs.schs.put("s", t);
+    return new InstExpTinkerpop(new LinkedList());
+  }
+
+  @Override
+  public SchExpTinkerpop visitSchExpTinkerpop(Unit params, AqlTyping exp) {
+    return new SchExpTinkerpop();
+  }
+
+  @Override
+  public EdsExpTinkerpop visitEdsExpTinkerpop(Unit params, AqlTyping exp) {
+    return new EdsExpTinkerpop();
+  }
+
+  @Override
+  public PragmaExpBitsy visitPragmaExpBitsy(Unit params, AqlTyping exp) {
+    return new PragmaExpBitsy(Collections.emptyList());
+  }
+
+  @Override
+  public PragmaExpTinkerpopInstExport visitPragmaExpTinkerpopInstExport(
+      Unit params, AqlTyping exp) {
+    SchExpVar e = new SchExpVar("s");
+    TyExpVar x = new TyExpVar("t");
+    InstExpVar i = new InstExpVar("i");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", x);
+    exp.defs.insts.put("i", e);
+    return new PragmaExpTinkerpopInstExport(i, Collections.emptyList());
+  }
+
+  @Override
+  public PragmaExpTinkerpop visitPragmaExpTinkerpop(Unit params, AqlTyping exp) {
+    return new PragmaExpTinkerpop(Collections.emptyList(), Collections.emptyList());
+  }
+
+  @Override
+  public EdsExpFromMsCatalog visitEdsExpFromMsCatalog(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpMsQuery(new TyExpSql(), "Other");
+    InstExp i = new InstExpVar("i");
+    exp.defs.insts.put("i", s);
+    return new EdsExpFromMsCatalog(i, s, Collections.emptyList());
+  }
+
+  @Override
+  public ColimSchExpSimplify visitColimSchExpSimplify(Unit params, AqlTyping exp) {
+    ColimSchExp x = new ColimSchExpVar("sc");
+    exp.defs.scs.put("sc", new THashSet());
+
+    return new ColimSchExpSimplify(x, Collections.emptyList());
+  }
+
+  @Override
+  public EdsExpSigma visitEdsExpSigma(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    EdsExp c = new EdsExpVar("c");
+    MapExp m = new MapExpVar("m");
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.maps.put("m", new Pair(s1, s2));
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.eds.put("c", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    exp.prog.exps.put(
+        "c", new EdsExpRaw(s1, Collections.emptyList(), Collections.emptyList(), Unit.unit));
+    exp.prog.exps.put("m", m);
+
+    return new EdsExpSigma(m, c);
+  }
+
+  @Override
+  public EdsExpSql visitEdsExpSql(Unit params, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpSql();
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    return new EdsExpSql(s);
+  }
+
+  @Override
+  public ColimSchExpPseudo visitColimSchExpPseudo(Unit params, AqlTyping exp) {
+    TyExp t = new TyExpVar("t");
+    exp.defs.tys.put("t", Unit.unit);
+    return new ColimSchExpPseudo(
+        t,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @Override
+  public MapExpPseudo visitMapExpPseudo(Unit params, AqlTyping exp) {
+    exp.defs.scs.put("c", Collections.emptySet());
+    return new MapExpPseudo(new ColimSchExpVar("c"));
+  }
+
+  @Override
+  public QueryExpRext visitQueryExpRext(Unit params, AqlTyping exp) {
+    exp.defs.tys.put("t", Unit.unit);
+    TyExpVar t = new TyExpVar("t");
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.schs.put("s3", t);
+
+    SchExpVar s1 = new SchExpVar("s1");
+    SchExpVar s2 = new SchExpVar("s2");
+    SchExpVar s3 = new SchExpVar("s3");
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("s3", new SchExpEmpty(t));
+
+    QueryExpVar m12 = new QueryExpVar("q12");
+    QueryExpVar m13 = new QueryExpVar("q13");
+
+    exp.defs.qs.put("q12", new Pair(s1, s2));
+    exp.defs.qs.put("q13", new Pair(s1, s3));
+
+    return new QueryExpRext(m12, m13, Collections.emptyList());
+  }
+
+  @Override
+  public SchExpUnit visitSchExpUnit(Unit params, AqlTyping r) {
+    TyExp t = new TyExpVar("t");
+    r.defs.tys.put("t", Unit.unit);
+    return new SchExpUnit(t);
+  }
+
+  @Override
+  public QueryExpFromInst visitQueryExpFromInst(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s1);
+    return new QueryExpFromInst(i);
+  }
+
+  @Override
+  public EdsExpLearn visitEdsExpLearn(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i1");
+    InstExp j = new InstExpVar("i2");
+    exp.defs.schs.put("s1", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i1", s1);
+    exp.defs.insts.put("i2", s1);
+
+    return new EdsExpLearn(i, j);
+  }
+
+  @Override
+  public QueryExpChase visitQueryExpChase(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.qs.put("q", new Pair<>(s1, s2));
+    exp.defs.eds.put("c", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    EdsExpVar c = new EdsExpVar("c");
+    return new QueryExpChase(q, c);
+  }
+
+  @Override
+  public QueryExpReformulate visitQueryExpReformulate(Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    QueryExp q = new QueryExpVar("q");
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.qs.put("q", new Pair<>(s1, s2));
+    exp.defs.eds.put("c", s1);
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+    EdsExpVar c = new EdsExpVar("c");
+    return new QueryExpReformulate(q, c, s2, "0");
+  }
+
+  @Override
+  public <Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2>
+      TransExpSubseteq<Gen1, Sk1, Gen2, Sk2, X1, Y1, X2, Y2> visitTransExpSubseteq(
+          Unit params, AqlTyping exp) {
+    SchExp s1 = new SchExpVar("s1");
+    SchExp s2 = new SchExpVar("s2");
+    TyExp t = new TyExpVar("t");
+    QueryExp q1 = new QueryExpVar("q1");
+    QueryExp q2 = new QueryExpVar("q2");
+
+    exp.defs.schs.put("s1", t);
+    exp.defs.schs.put("s2", t);
+
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.qs.put("q1", new Pair<>(s1, s2));
+    exp.defs.qs.put("q2", new Pair<>(s1, s2));
+
+    exp.prog.exps.put("s1", new SchExpEmpty(t));
+    exp.prog.exps.put("s2", new SchExpEmpty(t));
+    exp.prog.exps.put("t", new TyExpEmpty());
+
+    return new TransExpSubseteq(q1, q2);
+  }
+
+  @Override
+  public <Gen, Sk, X, Y> InstExpCore<Gen, Sk, X, Y> visitInstExpCore(Unit param, AqlTyping exp) {
+    SchExp s = new SchExpVar("s");
+    TyExp t = new TyExpVar("t");
+    InstExp i = new InstExpVar("i");
+    exp.defs.schs.put("s", t);
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.insts.put("i", s);
+    return new InstExpCore(i);
+  }
+
+  @Override
+  public EdsExpInfer visitEdsExpInfer(Unit params, AqlTyping exp) {
+    TyExp t = new TyExpVar("t");
+    SchExp s = new SchExpVar("s");
+    EdsExp c1 = new EdsExpVar("c1");
+    EdsExp c2 = new EdsExpVar("c2");
+    exp.defs.tys.put("t", Unit.unit);
+    exp.defs.schs.put("s", t);
+    exp.defs.eds.put("c1", s);
+    exp.defs.eds.put("c2", s);
+    return new EdsExpInfer(c1, c2, s, Collections.emptyList());
+  }
 }


### PR DESCRIPTION
`AqlHelp` generates the CQL HTML manual that ships at `categoricaldata.net/help/`, it had drifted out of sync with the language and crashed before writing a single page, which is a big part of why the published docs go stale (related: #104). 

This PR makes the generator produce the full manual again, wires it into CI as a quality gate, and fixes the JDK/formatting toolchain so the build works on modern JDKs. 

## How it is fixed

`AqlHelp` walks every `AqlSyntax` / `AqlOption` / `ProverName` reflectively. Four independent "feature added, doc path never updated -> hard failure" bugs were fixed. The new handlers are documentation-only prototypes and should not have any ompact on the real typing/eval.

## New things in the CI

This PR also builds the doc as part of CI, it ensures that new changes don't break the documentation. It also paves the way to publish the docs through git actions