### PR TITLE
ci: publish generated docs to the website repo on master

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,52 @@
+name: Deploy docs to website
+
+# Regenerate the CQL HTML manual and push it to the website repo's help/ directory.
+# Only help/ is touched, so the hand-authored pages on the site are never affected.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Generate and publish help/
+    runs-on: ubuntu-latest
+    if: github.repository == 'CategoricalData/CQL'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate the CQL manual
+        run: ./gradlew generateHelp
+        timeout-minutes: 20
+
+      - name: Check out the website repo (via deploy key)
+        uses: actions/checkout@v4
+        with:
+          repository: CategoricalData/categoricaldata.github.io
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          path: site
+
+      - name: Replace help/ and push if it changed
+        run: |
+          set -euo pipefail
+          rm -rf site/help
+          cp -r help site/help
+          cd site
+          git config user.name  "cql-docs-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add help
+          if git diff --cached --quiet; then
+            echo "No documentation changes — nothing to publish."
+          else
+            git commit -m "docs: refresh CQL manual from CQL@${GITHUB_SHA::7}"
+            git push
+          fi


### PR DESCRIPTION
This PR regenerates the HTML manual and publishes it to the website repo automatically! no more hand-copying `help/`.
  
## What it does
- On push to `master`, runs `./gradlew generateHelp`, then replaces *only* `help/` in `CategoricalData/categoricaldata.github.io` and pushes (no-op if unchanged).
- The hand-authored pages are never touched. This is important! Since it ensures the automated ci does not steam-rolls the published documentation
- Guarded to run only on `CategoricalData/CQL`; forks skip it.
  