### PR TITLE
ci: re-trigger docs deploy now that PAGES_DEPLOY_KEY is configured

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,7 @@ name: Deploy docs to website
 # Regenerate the CQL HTML manual and push it to the website repo's help/ directory.
 # Only help/ is touched, so the hand-authored pages on the site are never affected.
 
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Simple blank-space PR to trigger the docs pipeline now that tokens are in place