### PR TITLE
docs(AqlHelp): document the use_egglog_for_chase option

### DIFF
--- a/src/catdata/cql/exp/AqlHelp.java
+++ b/src/catdata/cql/exp/AqlHelp.java
@@ -303,6 +303,8 @@ public class AqlHelp {
       //		break;
       case check_warn_instead_of_fail:
         return "When true, check commans will emit warnings instead of stopping execution";
+      case use_egglog_for_chase:
+        return "When enabled, uses the egglog equality-saturation engine to compute the chase.";
       default:
         break;
     }


### PR DESCRIPTION
Added a `getOptionText2` case for `use_egglog_for_chase` so its manual page shows a real description instead of the "not yet documented" fallback.